### PR TITLE
feat(oauth-provider): pass context to custom jwt claims for multi-tenant support

### DIFF
--- a/docs/components/sidebar-content.tsx
+++ b/docs/components/sidebar-content.tsx
@@ -1581,38 +1581,6 @@ C0.7,239.6,62.1,0.5,62.2,0.4c0,0,54,13.8,119.9,30.8S302.1,62,302.2,62c0.2,0,0.2,
 				icon: () => <KeyRound className="size-4" />,
 			},
 			{
-				title: "MCP",
-				icon: () => (
-					<svg
-						width="1.2em"
-						height="1.2em"
-						viewBox="0 0 156 173"
-						fill="none"
-						xmlns="http://www.w3.org/2000/svg"
-					>
-						<path
-							d="M6 80.9117L73.8822 13.0294C83.255 3.65685 98.451 3.65685 107.823 13.0294C117.196 22.4019 117.196 37.598 107.823 46.9706L56.5581 98.2359"
-							stroke="currentColor"
-							strokeWidth="12"
-							strokeLinecap="round"
-						/>
-						<path
-							d="M57.2652 97.5289L107.823 46.9706C117.196 37.598 132.392 37.598 141.765 46.9706L142.118 47.324C151.491 56.6966 151.491 71.8926 142.118 81.2651L80.7248 142.659C77.6006 145.783 77.6006 150.848 80.7248 153.972L93.331 166.579"
-							stroke="currentColor"
-							strokeWidth="12"
-							strokeLinecap="round"
-						/>
-						<path
-							d="M90.853 29.9999L40.6482 80.2045C31.2756 89.5768 31.2756 104.773 40.6482 114.146C50.0208 123.518 65.2167 123.518 74.5893 114.146L124.794 63.941"
-							stroke="currentColor"
-							strokeWidth="12"
-							strokeLinecap="round"
-						/>
-					</svg>
-				),
-				href: "/docs/plugins/mcp",
-			},
-			{
 				title: "Organization",
 				icon: () => <Users2 className="w-4 h-4" />,
 				href: "/docs/plugins/organization",
@@ -1624,8 +1592,8 @@ C0.7,239.6,62.1,0.5,62.2,0.4c0,0,54,13.8,119.9,30.8S302.1,62,302.2,62c0.2,0,0.2,
 				icon: () => <LucideAArrowDown className="w-4 h-4" />,
 			},
 			{
-				title: "OIDC Provider",
-				href: "/docs/plugins/oidc-provider",
+				title: "OAuth Provider",
+				href: "/docs/plugins/oauth-provider",
 				icon: () => (
 					<svg
 						xmlns="http://www.w3.org/2000/svg"
@@ -1640,6 +1608,7 @@ C0.7,239.6,62.1,0.5,62.2,0.4c0,0,54,13.8,119.9,30.8S302.1,62,302.2,62c0.2,0,0.2,
 						<circle cx="7" cy="25" r="1" fill="currentColor"></circle>
 					</svg>
 				),
+				isNew: true,
 			},
 			{
 				title: "SSO",

--- a/docs/content/docs/plugins/api-key.mdx
+++ b/docs/content/docs/plugins/api-key.mdx
@@ -5,6 +5,12 @@ description: API Key plugin for Better Auth.
 
 The API Key plugin allows you to create and manage API keys for your application. It provides a way to authenticate and authorize API requests by verifying API keys.
 
+<Callout type="info">
+We recommend to utilize the [OAuth Provider Plugin](/docs/plugins/oauth-provider) whenever possible.
+
+The OAuth plugin provides additional security benefits over API Keys such as short-lived access tokens, key rotation, and centralized revocation.
+</Callout>
+
 ## Features
 
 - Create, manage, and verify API keys

--- a/docs/content/docs/plugins/mcp.mdx
+++ b/docs/content/docs/plugins/mcp.mdx
@@ -5,6 +5,10 @@ description: MCP provider plugin for Better Auth
 
 `OAuth` `MCP`
 
+<Callout type="warn">
+This plugin is deprecated in favor of the [OAuth Provider Plugin](/docs/plugins/oauth-provider).
+</Callout>
+
 The **MCP** plugin lets your app act as an OAuth provider for MCP clients. It handles authentication and makes it easy to issue and manage access tokens for MCP applications.
 
 ## Installation

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -959,8 +959,7 @@ If you are using "openid" and confidential MCP clients, you cannot disable the J
     import { mcpHandler } from "better-auth/plugins";
     import { z } from "zod";
 
-    const handler = mcpHandler(auth, (req, session) => {
-      // session contains the access token record with scopes and user ID
+    const handler = mcpHandler(auth, (req, jwt) => {
       return createMcpHandler(
         (server) => {
           server.tool(
@@ -969,7 +968,10 @@ If you are using "openid" and confidential MCP clients, you cannot disable the J
             { message: z.string() },
             async ({ message }) => {
               return {
-                content: [{ type: "text", text: `Tool echo: ${message}` }],
+                content: [{
+                  type: "text",
+                  text: `User ${jwt.sub}: ${message}`
+                }],
               };
             },
           );
@@ -995,59 +997,25 @@ If you are using "openid" and confidential MCP clients, you cannot disable the J
     export { handler as GET, handler as POST, handler as DELETE };
     ```
 
-    - Manually handle Errors
-
-    To manually check for errors, watch for "Unauthorized" responses (status code 401) when using `api.oAuth2introspectVerify` with access to `auth`.
+    - Using the client `verifyAccessToken` function
 
     ```ts
-    import { auth } from "@/lib/auth"; // Location of BetterAuth options
-    import { verifyAccessToken, handleMcpErrors } from "better-auth/plugins";
+    import { authClient } from "./client";
 
-    // this is pseudocode to show how to properly handle errors
     export const GET = async (req: Request) => {
-      const accessToken = req.headers.get('Authorization');
-      try {
-        const tokens = await auth.api.oAuth2introspectVerify();
-        // ...continue
-      } catch (error) {
-        try {
-          return handleMcpErrors(
-            error,
-            "https://api.example.com",
-          );
-        } catch (error) {
-          console.error(error as unknown as string);
-        }
-      }
-    }
-    ```
-
-    Or fully manual when using the `verifyAccessToken` function.
-
-    ```ts
-    import { verifyAccessToken, handleMcpErrors } from "better-auth/plugins";
-
-    // this is pseudocode to show how to properly handle errors
-    export const GET = async (req: Request) => {
-      const accessToken = req.headers.get('Authorization');
-      try {
-        const tokens = await verifyAccessToken(accessToken, {
+      const authorization = req.headers?.get("authorization") ?? undefined;
+      const accessToken = authorization?.startsWith("Bearer ")
+        ? authorization.replace("Bearer ", "")
+        : authorization;
+      const payload = await client.verifyAccessToken(
+        accessToken, {
           verifyOptions: {
-            audience: "https://api.example.com",
             issuer: "https://auth.example.com",
-          }
-        });
-        // ...continue
-      } catch (error) {
-        try {
-          return handleMcpErrors(
-            error,
-            "https://api.example.com",
-          );
-        } catch (error) {
-          console.error(error as unknown as string);
+            audience: "https://api.example.com",
+          },
         }
-      }
+      );
+      // ...continue
     }
     ```
   </Step>
@@ -1476,7 +1444,7 @@ The MCP endpoints moved from `/mcp` to the `/oauth2` equivalent.
 - `/oauth2/token` (previously `/mcp/token`)
 - `/oauth2/register` (previously `/mcp/register`)
 - `/mcp/get-session` removed as not oAuth2 compliant, use `/oauth2/introspect` instead
-- `/.well-known/oauth-protected-resource` removed, use the helper `mcpHandler` (or manually with `api.oAuth2introspectVerify`/`verifyAccessToken` and `handleMcpErrors`)
+- `/.well-known/oauth-protected-resource` removed, use the helper `mcpHandler` (or manually with the server `api.oAuth2introspectVerify` or the client `verifyAccessToken`)
 
 
 ### From [API Key](/docs/plugins/api-key)

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -1,0 +1,1509 @@
+---
+title: oAuth 2.1 Provider
+description: A Better Auth plugin that enables your auth server to serve as an oAuth 2.1 provider.
+---
+
+An **oAuth 2.1 Provider Plugin** that allows you to turn your authentication server into an oAuth provider with OIDC compatability allowing users and other services to authenticate with your API.
+
+The plugin has a secured configuration by default providing ease to users unfamiliar with the details of oAuth.
+
+<Callout type="info">
+Please report any issues or bugs on [GitHub](https://github.com/better-auth/better-auth).
+</Callout>
+
+**Key Features**:
+
+- **oAuth 2.1**: Restricted security practices to [oAuth 2.1](https://oauth.net/2.1/)
+- **OIDC compatability**: [OIDC](https://openid.net/specs/openid-connect-core-1_0.html)-compliant with the `openid` scope
+  - **UserInfo**: Endpoint providing current user details
+  - **id_token**: JWT-signed user information
+- **Dynamic Client Registration**: Allow clients to register clients dynamically.
+  - **Public Clients**: Support public clients for native mobile clients and user-agent clients (like AI)
+  - **Confidential Clients**: Supports confidential clients for web clients
+  - **Trusted Clients**: Configure hard-coded trusted clients with optional consent bypass.
+- **JWT Plugin compatability**: required by default with an option to disable
+  - **JWT Signing**: sign JWT tokens when requesting a `resource`
+  - **JWKS Verifiable**: verify tokens remotely at the [`/jwks`](/docs/plugins/jwt#verifying-the-token) endpoint
+- **Authorization Prompts**: prompts that initiate specific login flows
+  - **Consent**: Ensure consent is granted for each scope.
+- **Resource Endpoints**: Read and manage tokens.
+  - **Introspection**: [RFC7662](https://datatracker.ietf.org/doc/html/rfc7662)-compliant Introspection.
+  - **Revocation**: [RFC7009](https://datatracker.ietf.org/doc/html/rfc7662)-compliant Revocation.
+
+**Grants Supported**
+
+- **authorization_code**: Code for user token exchange with PKCE and S256 requirements.
+- **refresh_token**: Issue refresh tokens and handle access token renewal using `offline_access` scope.
+- **client_credentials**: Machine to Machine tokens for API communication.
+
+
+## Installation
+
+<Steps>
+  <Step>
+    ### Mount the Plugin
+
+    Add the OIDC plugin to your auth config. See [OIDC Configuration](#oidc-configuration) on how to configure the plugin.
+
+    ```ts title="auth.ts"
+    import { betterAuth } from "better-auth";
+    import { oauthProvider } from "better-auth/plugins";
+
+    const auth = betterAuth({
+      disabledPaths: [
+        "/token",
+      ],
+      plugins: [
+        jwt(),
+        oauthProvider({
+          loginPage: "/sign-in",
+          consentPage: "/consent",
+          // ...other options
+        })
+      ],
+    });
+    ```
+  </Step>
+
+  <Step>
+    ### Migrate the Database
+
+    Run the migration or generate the schema to add the necessary fields and tables to the database.
+
+    <Tabs items={["migrate", "generate"]}>
+      <Tab value="migrate">
+      ```bash
+      npx @better-auth/cli migrate
+      ```
+      </Tab>
+      <Tab value="generate">
+      ```bash
+      npx @better-auth/cli generate
+      ```
+      </Tab>
+    </Tabs>
+    See the [Schema](#schema) section to add the fields manually.
+  </Step>
+
+  <Step>
+    ### Add the Client Plugin
+
+    Add the OIDC client plugin to your auth client config.
+
+    ```ts
+    import { createAuthClient } from "better-auth/client";
+    import { oauthProviderClient } from "better-auth/client/plugins"
+    const authClient = createAuthClient({
+      plugins: [oauthProviderClient()],
+    });
+    ```
+  </Step>
+
+  <Step>
+    ### Add `./well-known` endpoints
+
+    Please add all [Well-Known endpoints](#well-known) to your project. The locations are provided as warnings if you are unsure.
+
+    - You **MUST** add the oAuth Authorization Server metadata endpoint at your issuer path (root if no path).
+    - If you are using the `openid` scope, you **MUST** add the openid configuration at your issuer path (root if no path).
+    - If you are using the resource server (ie for MCP), you **MUST** add the resource server metadata to your API, with the issuer path appended.
+
+  </Step>
+
+  <Step>
+    ### Create your first client
+
+    Register your first confidential client.
+
+    ```ts
+    const client = await auth.api.registerOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [redirectUri],
+			}
+		});
+    console.log(client); // You may add this to `trustedClients`
+    ```
+  </Step>
+</Steps>
+
+
+## Usage
+
+The plugin operates as an oAuth 2.1 server with OIDC compatable endpoints and JWT verifiable access tokens. The following provides more detailed information about each endpoint.
+
+### Dynamic Registeration Endpoint
+
+<Callout type="info">
+This endpoint supports [RFC7591](https://datatracker.ietf.org/doc/html/rfc7591) compliant client registration.
+</Callout>
+
+Once installed, you can utilize the OAuth Provider to manage authentication flows within your application.
+
+After the client is created, you will receive a `client_id` and `client_secret` that you can display to the user. The `client_secret` can only be provided once, ensure the user saves it.
+
+#### Setup
+
+To enable client registration set `allowDynamicClientRegistration: true` in your BetterAuth config.
+
+```ts title="auth.ts"
+oauthProvider({
+  allowDynamicClientRegistration: true,
+  // ... other options
+})
+```
+
+To enable unauthenticated client registration which allows for dynamically registered public clients, additionally set `allowUnauthenticatedClientRegistration: true` in your auth config.
+
+```ts title="auth.ts"
+oauthProvider({
+  allowDynamicClientRegistration: true,
+  allowUnauthenticatedClientRegistration: true,
+  // ... other options
+})
+```
+
+#### Basic Example
+
+To register a new OIDC client, use the `oauth2.register` method.
+
+```ts
+const client = await client.oauth2.register({
+  client_name: "My Client",
+  redirect_uris: ["https://client.example.com/callback"],
+});
+```
+
+For all endpoint parameters, see [RFC 7591 Registeration](https://datatracker.ietf.org/doc/html/rfc7591#section-2).
+
+Note the following parameters are not yet supported:
+- `jwks`
+- `jwks_uri`
+
+### Authorize Endpoint
+
+An [OAuth 2.1 authorization endpoint](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#name-authorization-endpoint). Since many of the details are not yet fully described, parts are adapted from the legacy [OAuth 2.0 Authorization Endpoint Section](https://datatracker.ietf.org/doc/html/rfc6749#section-3.1) but always implements the [differences from OAuth 2.0](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#name-differences-from-oauth-20).
+
+The Authorization Endpoint is the entry point for initiating an OAuth 2.1 authorization flows, requiring the grant type `authorization_code` in the options grant types list.
+
+#### Client Login Endpoint
+
+To generate an authorization request from your client, the authorization parameters should look something like the following:
+
+```ts title="/api/login/index.ts"
+import { randomBytes, createHash } from "crypto";
+
+// Save initial state
+const state = randomBytes(32).toString("base64url");
+const codeVerifier = randomBytes(32).toString("base64url");
+const codeChallenge = createHash("SHA-256")
+  .update(codeVerifier)
+  .digest()
+  .toString("base64url");
+const stateData = {
+  codeVerifier,
+  state,
+  redirectUri: "/dashboard",
+};
+// pseudocode set cookie
+await signedCookie(
+  "__Secure-auth.client-state",
+  JSON.stringify(stateData), {
+    httpOnly: true,
+    secure: true,
+    sameSite: "lax",
+    maxAge: 3600,
+    path: "/api/login",
+  }
+);
+
+// Generate and present app redirect_uri
+const searchParams = new URLSearchParams({
+  client_id: "my_client",
+  redirect_uri: "https://client.example.com/api/login/callback", // required
+  state: "123",
+  code_challenge: codeChallenge,
+  code_challenge_method: "S256",
+  response_type: "code",
+  scope: "openid email profile offline_access",
+});
+return {
+  redirect_uri: `https://auth.example.com/api/auth/oauth2/authorize?${searchParams.toString()}`,
+};
+```
+
+For all endpoint parameters, see [OAuth 2.1 Authorization Request](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#name-authorization-request).
+
+Important notes:
+- In OAuth 2.1, only `response_type: "code"` is supported.
+- `code_challenge_method: "plain"` will not be supported since this is a security vulnerability.
+
+**State**
+
+We recommend sending a state to mitigate cross-site request forgery (CSRF) attacks. This works by ensuring your client only responds to requests that your client initially requested.
+
+Generate a state value from your client and store on your client such as in a secure, HTTP-only cookie or database.
+
+**Code Challenge**
+
+Code challenges helps protect the authorization `code` returned from the authorization endpoint.
+
+To do so, a code challenge is derived from the code verifier, used and sent in a [Proof Key for Code Exchange (PKCE)](https://datatracker.ietf.org/doc/html/rfc7636) to the Authorization Server.
+
+Now at your `redirect_uri`, check to see if the returned state matches the initial state.
+
+#### Client Callback Endpoint
+
+This endpoint converts the redirect code into tokens. See [Token Endpoint](#token-endpoint) for further details.
+
+```ts title="/api/login/callback.ts"
+// pseudocode get cookie
+const stateCookie = JSON.parse(
+  (await getSignedCookie("__Secure-auth.client-state")) ?? "{}",
+);
+
+// Compare states if returned
+if (stateCookie?.state !== query?.state) {
+  throw new Error("Login state does not match.");
+}
+
+// Exchange code for tokens
+const tokens = await $fetch(
+  `https://auth.example.com/api/auth/oauth2/token`,
+  {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      grant_type: "authorization_code",
+      code: query.code, // passed from the query parameter
+      code_verifier: stateCookie.codeVerifier, // stored in the cookie
+      client_id: "my_client",
+      client_secret: "my_client_secret", // required
+      scope: "openid email profile offline_access",
+      resource: "https://api.example.com", // optional
+      redirect_uri: "https://client.example.com/api/login/callback", // required since originally sent
+    }),
+  },
+);
+```
+
+
+### Token Endpoint
+
+By default, the token endpoint supports providing tokens for the following grants:
+
+- "authorization_code"
+- "client_credentials"
+- "refresh_token"
+
+#### Authorization code grant
+
+The authorization code grant enables clients to obtain access user access tokens and optionally refresh tokens (with the "offline_access" scope).
+
+#### Client credentials grant
+
+The client credentials grant enables clients to obtain machines to obtain access tokens.
+
+#### Refresh token grant
+
+The refresh token grant enables clients to update their access token without needing the user to login again.
+
+
+### Consent Endpoint
+
+Accept or deny user consent for a set of scopes.
+
+<APIMethod path="/oauth2/consent" method="POST">
+```ts
+type oauth2Consent = {
+  /**
+   * Accept or deny user consent for a set of scopes
+   */
+  accept: boolean = true,
+}
+```
+</APIMethod>
+
+### Introspect Endpoint
+
+[RFC7662](https://datatracker.ietf.org/doc/html/rfc7662)-compliant Introspection.
+
+This endpoint provides details of the provided token. If the token is additionally tied to a session, the endpoint will ensure the session is `active`.
+
+<APIMethod path="/oauth2/introspect" method="POST">
+```ts
+type oauth2Introspect = {
+  /**
+   * Client Id.
+   */
+  client_id: string = "my_client",
+  /**
+   * Client Secret.
+   */
+  client_secret: string = "my_client_secret",
+  /**
+   * An access token or refresh token
+   */
+  token: string = "xyz",
+  /**
+   * Type of token when known.
+   */
+  token_type_hint?: "access_token" | "refresh_token" = "access_token",
+}
+```
+</APIMethod>
+
+### Revoke Endpoint
+
+[RFC7009](https://datatracker.ietf.org/doc/html/rfc7662)-compliant Revocation.
+
+This endpoint revokes the provided token.
+
+- opaque `access_token`: immediately removes that `access_token` from the database. `refresh_token` is still valid.
+- JWT `access_token`: verifies that token is safe to remove from client storage.
+- `refresh_token`: removes all `access_tokens` granted using that `refresh_token` and removes the `refresh_token` to prevent further token issuance.
+
+For an `access_token` type, 
+
+<APIMethod path="/oauth2/revoke" method="POST">
+```ts
+type oauth2Revoke = {
+  /**
+   * Client Id.
+   */
+  client_id: string = "my_client",
+  /**
+   * Client Secret.
+   */
+  client_secret: string = "my_client_secret",
+  /**
+   * An access token or refresh token
+   */
+  token: string = "xyz",
+  /**
+   * Type of token when known.
+   */
+  token_type_hint?: "access_token" | "refresh_token" = "access_token",
+}
+```
+</APIMethod>
+
+### UserInfo Endpoint
+
+The UserInfo Endpoint provides [OIDC](https://openid.net/specs/openid-connect-core-1_0.html)-compliant user information. Available at `/oauth2/userinfo`, the endpoint requires a valid access token with at least the scope `openid`.
+
+<Endpoint path="/oauth2/userinfo" method="GET" />
+```ts title="client-app.ts"
+// Example of how a client would use the UserInfo endpoint
+const response = await fetch('https://your-domain.com/api/auth/oauth2/userinfo', {
+  headers: {
+    'Authorization': 'Bearer ACCESS_TOKEN'
+  }
+});
+
+const userInfo = await response.json();
+// userInfo contains user details based on the scopes granted
+```
+
+The UserInfo endpoint returns different claims based on the scopes that were granted during authorization:
+
+- `openid`: Returns the user's ID (`sub` claim)
+- `profile`: Returns `name`, `picture`, `given_name`, `family_name`
+- `email`: Returns `email` and `email_verified`
+
+The `getAdditionalUserInfoClaim` function receives the user object, requested scopes array, and the client, allowing you to conditionally include claims based on the scopes granted during authorization. These additional claims will be included in both the UserInfo endpoint response and the ID token.
+
+
+### Well known
+
+#### Openid Configuration
+
+Provides [OpenID connect discovery metadata](https://openid.net/specs/openid-connect-discovery-1_0.html) located at `/.well-known/openid-configuration`.
+
+This endpoint requires the scope `openid`.
+
+You **must** add the configuration at the issuer path. If an issuer is unset, this will be your basePath `/api/auth`.
+If this path is not at the root and you don't have an openid-configuration already at the root, we recommend you to add one in case a client incorrectly hard-coded `/.well-known/openid-configuration` (ignoring the issuer path in the spec).
+
+NOTE: For issuers with paths, OpenId utilizes path appending, thus any path on the issuer should be prepended before `/.well-known/openid-configuration`. If no issuer path is specified, the path should start at the root.
+
+```ts title="[issuer-path]/.well-known/openid-configuration/route.ts"
+import { oauthProviderOpenIdConfigMetadata } from "better-auth/plugins";
+import { auth } from "@/lib/auth";
+
+export const GET = oauthProviderOpenIdConfigMetadata(auth);
+```
+
+
+#### oAuth Authorization Server
+
+Provides [RFC8414](https://datatracker.ietf.org/doc/html/rfc8414)-compliant metadata located at `/.well-known/oauth-authorization-server`.
+
+You **must** add the configuration at the issuer path. If an issuer is unset, this will be your basePath `/api/auth`.
+
+NOTE: For issuers with paths, oAuth 2.1 Authorization Server utilizes path insertion, thus any path on the issuer should be appended after `/.well-known/oauth-authorization-server`. If no issuer path is specified, the path should start at the root.
+
+```ts title="/.well-known/oauth-authorization-server/[issuer-path]/route.ts"
+import { oauthProviderAuthServerMetadata } from "better-auth/plugins";
+import { auth } from "@/lib/auth";
+
+export const GET = oauthProviderAuthServerMetadata(auth);
+```
+
+
+## API Server
+
+This section shows how your API should verify tokens received from your clients.
+
+### Verification
+
+#### JWT Verification
+
+- Verify the token is valid:
+  - Validate the _signature_ using the JWKS.
+  - Check the `iss` (issuer) and `aud` (audience) claims.
+  - Verify the `exp` (expiration) and (if sent) `nbf` claim.
+- Validate the appropriate `scope` for each endpoint.
+
+#### Opaque Access Tokens
+
+- Send the received token to `/oauth2/introspect` and assert that `active: true` is returned.
+- Validate the appropriate `scope` for each endpoint.
+
+#### Recommendations
+
+The simplest approach is to _only accept JWT-formatted access tokens_ for your API and deny opaque tokens.
+
+**Benefits**:
+- **Fast**: locally verifiable, no network call required.
+- **Future-proof**: independent of the authorization server after issuance.
+- **No client secret needed**: the API can validate tokens without confidential client credentials.
+
+Accepting _opaque access tokens in addition to JWT tokens_ is possible, but comes with trade-offs.
+
+**Benefits**:
+- Immediate token and client validation.
+- Client does not require a `resource` parameter (depending on authorization server configuration).
+
+**Drawbacks**:
+- **DOS**: If the client is external (ie external APIs, MCP agents), opaque `access_token` verifications can overload your authorization server.
+- **Performance**: Each token requires a network call to the introspection endpoint.
+- **Audience limitation**: The authorization server can only issue tokens with a single audience.
+- **Secret required**: Introspection typically requires a `client_secret`, which public clients cannot safely provide.
+  - NOTE: Introspection bearer token and Private Key JWT methods are not yet implemented.
+
+
+### Scopes vs. Permissions
+
+- **Scopes** define what a client application *requests* on behalf of a user. They are usually coarse-grained labels included in an access token.
+- **Permissions** define the fine-grained actions a user (or service) is actually allowed to perform on resources, typically enforced at the resource server.
+
+In practice, you may also combine approaches depending on system complexity and how your resource server handles authorization.
+
+**Scopes and Permissions are the Same**
+
+Each scope directly represents a permission.
+- Example: A scope `read:post` corresponds exactly to the permission `read:post`.
+
+_Pros_:
+- Simple to implement and reason about.
+- No extra mapping logic required.
+
+_Cons_:
+- Access tokens can become large if permissions are very detailed, especially with JWTs.
+- Limited flexibility for future, more granular permissions.
+
+**Scopes and Permissions are Different**
+
+Scopes represent high-level access categories, and each scope maps to one or more underlying permissions.
+
+- **Example:** A scope `view:post` could map to:
+  - `read:post:content`
+  - `read:post:metadata` (but only for posts the user owns)
+
+_Pros_:
+- Flexible and scalable for complex systems.
+- Tokens remain compact, since only scopes are included, not all permissions.
+
+_Cons_:
+- The resource server must resolve scopes into permissions for each request.
+- Adds complexity to implementation and authorization checks.
+
+
+## Configuration
+
+
+### Login Screen
+
+When a user is redirected to the OIDC provider for authentication, if they are not already logged in, they will be redirected to the login page. You can customize the login page by providing a `loginPage` option during initialization.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+
+export const auth = betterAuth({
+  plugins: [oauthProvider({
+    loginPage: "/sign-in"
+  })]
+})
+```
+
+You don't need to handle anything from your side; when a new session is created, the plugin will handle continuing the authorization flow.
+
+
+### Consent Screen
+
+When a user is redirected to the OIDC provider for authentication, they may be prompted to authorize the application to access their data. This is known as the consent screen. By default, Better Auth will display a sample consent screen. You can customize the consent screen by providing a `consentPage` option during initialization.
+
+**Note**: Trusted clients with `skipConsent: true` will bypass the consent screen entirely, providing a seamless experience for first-party applications.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+
+export const auth = betterAuth({
+  plugins: [oauthProvider({
+    consentPage: "/path/to/consent/page"
+  })]
+})
+```
+
+The plugin will redirect the user to the specified path with `consent_code`, `client_id` and `scope` query parameters. You can use this information to display a custom consent screen. Once the user consents, you can call `oauth2.consent` to complete the authorization.
+
+<Endpoint path="/oauth2/consent" method="POST" />
+
+The consent endpoint supports two methods for passing the consent code:
+
+**Method 1: URL Parameter**
+```ts title="consent-page.ts"
+// Get the consent code from the URL
+const params = new URLSearchParams(window.location.search);
+
+// Submit consent with the code in the request body
+const consentCode = params.get('consent_code');
+if (!consentCode) {
+	throw new Error('Consent code not found in URL parameters');
+}
+
+const res = await client.oauth2.consent({
+	accept: true, // or false to deny
+	consent_code: consentCode,
+});
+```
+
+**Method 2: Cookie-Based**
+```ts title="consent-page.ts"
+// The consent code is automatically stored in a signed cookie
+// Just submit the consent decision
+const res = await client.oauth2.consent({
+	accept: true, // or false to deny
+	// consent_code not needed when using cookie-based flow
+});
+```
+
+Both methods are fully supported. The URL parameter method works well with mobile apps and third-party contexts, while the cookie-based method provides a simpler implementation for web applications.
+
+
+### Trusted Clients
+
+For first-party applications and internal services, you can configure trusted clients directly in your OIDC provider configuration. Trusted clients bypass database lookups for better performance and can optionally skip consent screens for improved user experience.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+import { oauthProvider } from "better-auth/plugins";
+
+const auth = betterAuth({
+  plugins: [
+    oauthProvider({
+      loginPage: "/sign-in",
+      trustedClients: [
+        {
+          clientId: "internal-dashboard",
+          clientSecret: "secure-secret-here",
+          name: "Internal Dashboard",
+          type: "web",
+          redirectUris: ["https://dashboard.company.com/auth/callback"],
+          disabled: false,
+          skipConsent: true, // Skip consent for this trusted client
+          metadata: { internal: true },
+        },
+        {
+          clientId: "mobile-app",
+          clientSecret: "mobile-secret", 
+          name: "Company Mobile App",
+          type: "native",
+          redirectUris: ["com.company.app://auth"],
+          disabled: false,
+          skipConsent: false, // Still require consent if needed
+          metadata: {},
+        },
+      ]
+  })]
+})
+```
+
+### Scopes
+
+Scopes allow clients specific access to specific resources.
+By default, we support the following scopes are supported:
+
+- `openid`: Returns the user's ID (`sub` claim).
+- `profile`: Returns name, picture, given_name, family_name
+- `email`: Returns email and email_verified
+- `offline_access`: Returns a refresh token
+
+The scopes configuration can contain as many or as few scopes as you wish! Note that `openid` is required to be considered an OIDC server, otherwise this is a standard OAuth 2.1 server. All supported scopes must be in this array.
+
+```ts title="auth.ts"
+oauthProvider({
+  scopes: [ "openid", "profile", "offline_access", "read:post", "write:post" ],
+})
+```
+
+### Claims
+
+Claims are fields defined in your access and id tokens. You can add more claims using the `customClaims`.
+
+By internally, we support the following claims are supported: ["sub", "iss", "aud", "exp", "iat", "sid", "scope", "azp"].
+
+The claims configuration can only be appended to the internal supported claims. Claims should be namespaced when possible to avoid potential future conflicts.
+
+```ts title="auth.ts"
+oauthProvider({
+  customClaims: [ "locale", "https://example.com/roles" ],
+  // Attach claims to id tokens
+  customIdTokenClaims: (_user: User, _scopes: string[]) => {
+    return {
+      locale: "en-GB",
+    };
+  },
+  // Attach claims to access tokens
+  customJwtClaims: (_user: User, _scopes: string[]) => {
+    return {
+      "https://example.com/roles": ["admin", "editor"],
+    };
+  },
+  // Additional user info claims
+  getAdditionalUserInfoClaim: (_user: User, _scopes: string[]) => {
+    return {
+      locale: "en-GB",
+      "https://example.com/roles": ["admin", "editor"],
+    };
+  },
+})
+```
+
+### Expirations
+
+Each token type and grant type can independently can set a default expiration.
+
+- `accessTokenExpiresIn` defaults 1 hour
+- `m2mAccessTokenExpiresIn` defaults 1 hour
+- `idTokenExpiresIn` defaults 10 hours
+- `refreshTokenExpiresIn` defaults 30 days
+- `codeExpiresIn` defaults 10 minutes
+
+Additionally, Access Tokens can set lower expirations based on scopes. This is useful for higher-privelege scopes that require shorter expiration times. The earliest expiration will take precendence. If not specified, the default will take place. Note: values should be lower than the defaults `accessTokenExpiresIn` and `m2mAccessTokenExpiresIn`.
+
+```ts title="auth.ts"
+oauthProvider({
+  scopeExpirations: {
+    "write:payments": "5m",
+    "read:payments": "30m",
+  },
+})
+```
+
+
+### Registration
+
+#### Dynamic Client Registration
+
+Dynamic registration allows for authorized registration of both public and confidential clients.
+
+```ts title="auth.ts"
+oauthProvider({
+  allowDynamicClientRegistration: true, // [!code highlight]
+})
+```
+
+Unauthenticated client registration additionally allows for public clients (never confidential) to register without an authorization header. This is especially useful for an MCP to dynamically register themselves as a public client.
+
+```ts title="auth.ts"
+oauthProvider({
+  allowDynamicClientRegistration: true,
+  allowUnauthenticatedClientRegistration: true, // [!code highlight]
+})
+```
+
+#### Dynamic Client Registration Expiration
+
+You can additionally set an expiration time for how long a confidential client should last for. By default, dynamically registered confidential clients do not expire.
+
+```ts title="auth.ts"
+oauthProvider({
+  allowDynamicClientRegistration: true,
+  clientRegistrationClientSecretExpiration: "30d", // [!code highlight]
+})
+```
+
+#### Dynamic Client Registration Scopes
+
+To set a list of default scopes for newly registered clients when scopes parameter is not sent, set the `clientRegistrationDefaultScopes` field. All scopes must be defined in `scopes`.
+
+```ts title="auth.ts"
+oauthProvider({
+  scopes: ["reader", "editor"],
+  clientRegistrationDefaultScopes: ["reader"], // [!code highlight]
+})
+```
+
+To also set a list of allowed scopes for newly registered clients when scopes parameter is not sent, set the `clientRegistrationAllowedScopes` field. These are **in addition** to the `clientRegistrationDefaultScopes`. All scopes must be defined in `scopes`.
+
+```ts title="auth.ts"
+oauthProvider({
+  scopes: ["reader", "editor"],
+  clientRegistrationDefaultScopes: ["reader"],
+  clientRegistrationAllowedScopes: ["editor"], // [!code highlight]
+})
+```
+
+
+### Storage
+
+By default all secrets are `hashed` by default on the database. This helps protect the `client_secret` in case of a database leak.
+
+- **storeClientSecret**: the storage method of application `client_secrets`. Only when `disableJwtPlugin: true`, the client secret shall rather be `encrypted`.
+- **storeTokens**: the storage method of token values, specifically session refresh tokens and opaque access tokens.
+
+
+### Refresh Token Customization
+
+You can choose to format your session tokens in a different string format using the `encodeRefreshToken` and `decodeRefreshToken` functions.
+
+These functions allow you to add additional functionality on the refresh token itself such as refresh token encryption or storage for session replay attacks.
+
+If defined, both `encodeRefreshToken` and `decodeRefreshToken` functions. must be defined.
+
+Example with change in refresh token format with backwards compatablity with original token-only format:
+
+```ts title="auth.ts"
+oauthProvider({
+  encodeRefreshToken: (token, sessionId) => {
+    const res = sessionId ? `1.${token}.${sessionId}` : token;
+    return res;
+  },
+  decodeRefreshToken: (token) => {
+    const tokenSplit = token.split('.');
+    if (tokenSplit.length === 3 && tokenSplit.at(0) === '1') {
+      return {
+        token: tokenSplit.at(1),
+        sessionId: tokenSplit.at(2),
+      };
+    }
+    return { token };
+  },
+})
+```
+
+Pseudocode for a token encryption method:
+
+```ts title="auth.ts"
+import { CompactEncrypt, compactDecrypt } from 'jose'
+
+const secret = "SOME_SECRET_OR_KEY"
+const alg = "A256KW"
+const enc = "A256GCM"
+
+const auth = betterAuth({
+  plugins: [oauthProvider({
+    encodeRefreshToken: (token, sessionId) {
+      const value = JSON.stringify({
+        sessionId,
+        token,
+      });
+      const jwe = await new CompactEncrypt(Buffer.from(value))
+        .setProtectedHeader({ alg, enc })
+        .encrypt(secret);
+      return jwe;
+    },
+    decodeRefreshToken: (token) {
+      const { plaintext } = await compactDecrypt(token, secret);
+      const payload = new TextDecoder().decode(plaintext);
+      return JSON.parse(payload);
+    },
+  })]
+})
+```
+
+
+### Advertised Metadata
+
+The metadata endpoint can be customized so that the publicized scopes and claims differ from those which the server can deliver. This can prevent showcasing all your supported scopes and claims on your metadata endpoint.
+
+All scopes and claims inside the advertisedMetadata section MUST be listed in `scopes` and `customClaims` respectively otherwise initialization will fail.
+
+#### Scopes
+
+```ts title="auth.ts"
+oauthProvider({
+  scopes: ["openid", "profile", "email", "offline_access", "read:post"],
+  advertisedMetadata: {
+    scopes_supported: ["openid", "profile", "read:post"],
+  },
+})
+```
+
+#### Claims
+
+Claims are in addition to the internally supported claims which are automatically determined by `scopes`.
+
+```ts title="auth.ts"
+oauthProvider({
+  claims_supported: ["https://client.example.com/roles"],
+  advertisedMetadata: {
+    claims_supported: ["https://client.example.com/roles"],
+  },
+})
+```
+
+### Disable JWT Plugin
+
+By default, access and id tokens can be issued and verified through the JWT plugin.
+
+You can disable the JWT requirement in which access tokens will always be opaque and id tokens are always signed in `HS256` using the `client_secret`. Note that disabling the JWT Plugin is still OIDC compliant, `/userinfo` still works and signed `id_token` is still provided.
+
+Key Differences:
+- Providing a valid `resource` will always provide you with an opaque access token instead of an JWT formatted token.
+- `id_token` is not returned for public clients, but the `access_token` returned can still utilize the `/oauth2/userinfo` endpoint to obtain the user data.
+- `id_token` for a confidential client is signed by their `client_secret`.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+import { oauthProvider } from "better-auth/plugins";
+
+const auth = betterAuth({
+  plugins: [
+    oauthProvider({
+      disableJwtPlugin: true, // [!code highlight]
+      loginPage: "/sign-in",
+      consentPage: "/consent",
+      // ...other options
+    })
+  ],
+});
+```
+
+
+### MCP
+
+You can easily make your APIs MCP-compatabile simply by adding a resource server which directs users to this oAuth2.1 authorization server.
+
+<Callout type="info">
+If you are using "openid" and confidential MCP clients, you cannot disable the JWT plugin since `id_token` verification may not necessarily be supported via a `client_secret`.
+</Callout>
+
+#### Installation
+
+<Steps>
+  <Step>
+    ### Ensure Well Known Paths are correct
+
+    See [well-known endpoints](#well-known).
+  </Step>
+
+  <Step>
+    ### Add oAuth Protected Resource Metadata to your API
+
+    NOTE: For resources with paths, oAuth 2.1 Authorization Server utilizes path insertion, thus any path should be appended after `/.well-known/oauth-protected-resource`.
+
+    - Automatic (if you have access to the better-auth configuration)
+
+    ```ts title="/.well-known/oauth-protected-resource/[resource-path]/route.ts"
+    import { oauthProviderProtectedResourceMetadata } from "better-auth/plugins";
+    import { auth } from "@/lib/auth";
+
+    export const GET = oauthProviderProtectedResourceMetadata(auth);
+    ```
+
+    - Manual (without access to your better-auth configuration)
+
+    Type support is recommended and may be downloaded into your API as a dev package.
+
+    ```ts title="/.well-known/oauth-protected-resource/[resource-path]/route.ts"
+    import type { ResourceServerMetadata } from "better-auth";
+
+    export const GET = async () => {
+      const metadata: ResourceServerMetadata = {
+        resource: "https://api.example.com", // must match the `aud` claim
+      };
+
+      return new Response(JSON.stringify(metadata), {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+    };
+    ```
+  </Step>
+
+  <Step>
+    ### Handle MCP Errors for your API
+
+    - Using `mcpHandler` helper
+
+    ```ts title="api/[transport]/route.ts"
+    import { auth } from "@/lib/auth";
+    import { createMcpHandler } from "@vercel/mcp-adapter";
+    import { mcpHandler } from "better-auth/plugins";
+    import { z } from "zod";
+
+    const handler = mcpHandler(auth, (req, session) => {
+      // session contains the access token record with scopes and user ID
+      return createMcpHandler(
+        (server) => {
+          server.tool(
+            "echo",
+            "Echo a message",
+            { message: z.string() },
+            async ({ message }) => {
+              return {
+                content: [{ type: "text", text: `Tool echo: ${message}` }],
+              };
+            },
+          );
+        },
+        {
+          capabilities: {
+            tools: {
+              echo: {
+                description: "Echo a message",
+              },
+            },
+          },
+        },
+        {
+          redisUrl: process.env.REDIS_URL,
+          basePath: "/api",
+          verboseLogs: true,
+          maxDuration: 60,
+        },
+      )(req);
+    });
+
+    export { handler as GET, handler as POST, handler as DELETE };
+    ```
+
+    - Manually handle Errors
+
+    To manually check for errors, watch for "Unauthorized" responses (status code 401) when using `api.oAuth2introspectVerify` with access to `auth`.
+
+    ```ts
+    import { auth } from "@/lib/auth"; // Location of BetterAuth options
+    import { verifyAccessToken, handleMcpErrors } from "better-auth/plugins";
+
+    // this is pseudocode to show how to properly handle errors
+    export const GET = async (req: Request) => {
+      const accessToken = req.headers.get('Authorization');
+      try {
+        const tokens = await auth.api.oAuth2introspectVerify();
+        // ...continue
+      } catch (error) {
+        try {
+          return handleMcpErrors(
+            error,
+            "https://api.example.com",
+          );
+        } catch (error) {
+          console.error(error as unknown as string);
+        }
+      }
+    }
+    ```
+
+    Or fully manual when using the `verifyAccessToken` function.
+
+    ```ts
+    import { verifyAccessToken, handleMcpErrors } from "better-auth/plugins";
+
+    // this is pseudocode to show how to properly handle errors
+    export const GET = async (req: Request) => {
+      const accessToken = req.headers.get('Authorization');
+      try {
+        const tokens = await verifyAccessToken(accessToken, {
+          verifyOptions: {
+            audience: "https://api.example.com",
+            issuer: "https://auth.example.com",
+          }
+        });
+        // ...continue
+      } catch (error) {
+        try {
+          return handleMcpErrors(
+            error,
+            "https://api.example.com",
+          );
+        } catch (error) {
+          console.error(error as unknown as string);
+        }
+      }
+    }
+    ```
+  </Step>
+</Steps>
+
+
+## Schema
+
+The OIDC Provider plugin adds the following tables to the database:
+
+### OAuth Application
+
+Table Name: `oauthClient`
+
+<DatabaseTable
+  fields={[
+    {
+      name: "id",
+      type: "string",
+      description: "Database ID of the OAuth client",
+      isPrimaryKey: true
+    },
+    {
+      name: "clientId",
+      type: "string",
+      description: "Unique identifier for each OAuth client",
+      isPrimaryKey: true
+    },
+    {
+      name: "clientSecret",
+      type: "string",
+      description: "Secret key for the OAuth client. Optional for public clients using PKCE.",
+      isOptional: true
+    },
+    {
+      name: "disabled",
+      type: "boolean",
+      description: "Field that indicates if the current application is disabled",
+      isOptional: true,
+    },
+    {
+      name: "scopes",
+      type: "string[]",
+      description: "Scopes this client is allowed to use",
+      isOptional: true,
+    },
+    {
+      name: "userId",
+      type: "string",
+      description: "ID of the user who owns the client. (optional)",
+      isOptional: true
+    },
+    {
+      name: "createdAt",
+      type: "Date",
+      description: "Timestamp of when the OAuth client was created" 
+    },
+    {
+      name: "updatedAt",
+      type: "Date",
+      description: "Timestamp of when the OAuth client was last updated"
+    },
+    {
+      name: "name",
+      type: "string",
+      description: "Name of the OAuth client",
+      isOptional: true,
+    },
+    {
+      name: "uri",
+      type: "string",
+      description: "Website Uri displayed on UI Screens",
+      isOptional: true,
+    },
+    {
+      name: "icon",
+      type: "string",
+      description: "Website Icon displayed on UI Screens",
+      isOptional: true,
+    },
+    {
+      name: "contacts",
+      type: "string[]",
+      description: "Client contact list (ie customer service emails, phone numbers) to be displayed on UI Screens",
+      isOptional: true,
+    },
+    {
+      name: "tos",
+      type: "string[]",
+      description: "Client Terms of Service displayed on UI Screens",
+      isOptional: true,
+    },
+    {
+      name: "policy",
+      type: "string[]",
+      description: "Client Privacy policy displayed on UI Screens",
+      isOptional: true,
+    },
+    {
+      name: "softwareId",
+      type: "string",
+      description: "Client-defined software identifier. This should remain the same across multiple versions for the same piece of software.",
+      isOptional: true,
+    },
+    {
+      name: "softwareVersion",
+      type: "string",
+      description: "Client-defined version number of the softwareId.",
+      isOptional: true,
+    },
+    {
+      name: "softwareStatement",
+      type: "string",
+      description: "Signed JWT containing the software metadata as signed claims.",
+      isOptional: true,
+    },
+    {
+      name: "redirectUris",
+      type: "string[]",
+      description: "Array of of redirect uris",
+      isRequired: true,
+    },
+    {
+      name: "tokenEndpointAuthMethod",
+      type: "string",
+      description: "Indicator of requested authentication method for the token endpoint. Supports: ['none', 'client_secret_basic', 'client_secret_post']",
+      isOptional: true,
+    },
+    {
+      name: "grantTypes",
+      type: "string[]",
+      description: "Array of supported grant types. Supports: ['authorization_code', 'client_credentials', 'refresh_token']",
+      isOptional: true,
+    },
+    {
+      name: "responseTypes",
+      type: "string[]",
+      description: "Array of supported grant types. Supports: ['code']",
+      isOptional: true,
+    },
+    {
+      name: "public",
+      type: "boolean",
+      description: "Indication if the client is confidential or public",
+      isOptional: true,
+    },
+    {
+      name: "type",
+      type: "string",
+      description: "Type of OAuth client. Supports: ['web', 'native', 'user-agent-based']",
+      isOptional: true,
+    },
+    {
+      name: "metadata",
+      type: "json",
+      description: "Additional metadata for the OAuth client",
+      isOptional: true,
+    },
+  ]}
+/>
+
+### Session
+
+Table Name: `oauthRefreshToken`
+
+<DatabaseTable
+  fields={[
+    {
+      name: "id",
+      type: "string",
+      description: "Database ID of the refresh token",
+      isPrimaryKey: true
+    },
+    {
+      name: "token",
+      type: "string",
+      description: "Hashed/encrypted refresh token",
+      isRequired: true,
+    },
+    {
+      name: "clientId",
+      type: "string",
+      description: "ID of the OAuth client",
+      isForeignKey: true,
+      isRequired: true,
+      references: { model: "oauthClient", field: "clientId" }
+    },
+    {
+      name: "sessionId",
+      type: "string",
+      description: "ID of the user associated with the token",
+      isForeignKey: true,
+      isRequired: false,
+      references: { model: "session", field: "id" },
+    },
+    {
+      name: "userId",
+      type: "string",
+      description: "ID of the user associated with the token",
+      isForeignKey: true,
+      isRequired: true,
+      references: { model: "user", field: "id" },
+    },
+    {
+      name: "scopes",
+      type: "string[]",
+      description: "Array of granted scopes",
+      isRequired: true,
+    },
+    {
+      name: "createdAt",
+      type: "Date",
+      description: "Timestamp when the access token was created" 
+    },
+    {
+      name: "expiresAt",
+      type: "Date",
+      description: "Timestamp when the token will expire",
+    },
+  ]}
+/>
+
+### OAuth Access Token
+
+Table Name: `oauthAccessToken`
+
+<DatabaseTable
+  fields={[
+    {
+      name: "id",
+      type: "string",
+      description: "Database ID of the opaque access token",
+      isPrimaryKey: true
+      isRequired: true,
+    },
+    {
+      name: "token",
+      type: "string",
+      description: "Hashed/encrypted access token",
+      isRequired: true,
+    },
+    {
+      name: "clientId",
+      type: "string",
+      description: "ID of the OAuth client",
+      isForeignKey: true,
+      isRequired: true,
+      references: { model: "oauthClient", field: "clientId" }
+    },
+    {
+      name: "sessionId",
+      type: "string",
+      description: "ID of the user associated with the token",
+      isForeignKey: true,
+      isOptional: true,
+      references: { model: "session", field: "id" },
+    },
+    {
+      name: "refreshId",
+      type: "string",
+      description: "ID of the refresh associated with the token",
+      isForeignKey: true,
+      isOptional: true,
+      references: { model: "oauthRefreshToken", field: "id" },
+    },
+    {
+      name: "scopes",
+      type: "string[]",
+      description: "Array of granted scopes",
+      isRequired: true,
+    },
+    {
+      name: "createdAt",
+      type: "Date",
+      description: "Timestamp when the access token was created" 
+    },
+    {
+      name: "expiresAt",
+      type: "Date",
+      description: "Timestamp when the token will expire",
+    },
+  ]}
+/>
+
+### OAuth Consent
+
+Table Name: `oauthConsent`
+
+<DatabaseTable
+  fields={[
+    {
+      name: "id",
+      type: "string",
+      description: "Database ID of the consent",
+      isPrimaryKey: true
+    },
+    {
+      name: "userId",
+      type: "string",
+      description: "ID of the user who gave consent",
+      isForeignKey: true,
+      references: { model: "user", field: "id" }
+    },
+    {
+      name: "clientId",
+      type: "string",
+      description: "ID of the OAuth client",
+      isForeignKey: true,
+      references: { model: "oauthClient", field: "clientId" }
+    },
+    {
+      name: "scopes",
+      type: "string",
+      description: "Comma-separated list of scopes consented to",
+      isRequired: true
+    },
+    {
+      name: "consentGiven",
+      type: "boolean",
+      description: "Indicates if consent was given",
+      isRequired: true
+    },
+    {
+      name: "createdAt",
+      type: "Date",
+      description: "Timestamp of when the consent was given" 
+    },
+    {
+      name: "updatedAt",
+      type: "Date",
+      description: "Timestamp of when the consent was last updated"
+    },
+  ]}
+/>
+
+## Options
+
+### Prefix
+
+Add a prefix to either or both opaque access tokens or refresh tokens. This is useful for Secret Scanners (ie. [GitHub Secret Scanners](https://docs.github.com/code-security/secret-scanning), [GitGuardian](https://www.gitguardian.com/solutions/secrets-scanning), [Trufflehog](https://github.com/trufflesecurity/trufflehog)) that may rely on the prefix to help determine the token format.
+
+We recommend to add a prefix to each of the following prior to your first production deployment. Once deployed consider them immutable, otherwise the following generate functions as specified:
+
+**opaqueAccessTokenPrefix**: `string | undefined` - add a prefix onto opaque access tokens. If previously deployed, utilize `generateOpaqueAccessToken` to perform this functionality instead.
+**refreshTokenPrefix**: `string | undefined` - add a prefix onto refresh tokens.  If previously deployed, utilize `generateRefreshToken` to perform this functionality instead.
+**clientSecretPrefix**: `string | undefined` - add a prefix onto client secrets.  If previously deployed, utilize `generateClientSecret` to perform this functionality instead.
+
+## Optimizations
+
+To improve lookup performance, map the field `client_id` on the table `oauthClient` to `id` through your database adapter.
+
+## Migrations
+
+### From [OIDC Provider](/docs/plugins/oidc-provider)
+
+#### Configuration
+
+- **`idTokenExpiresIn`** now defaults to `10 hours` (previously `1 hour` through `accessTokenExpiresIn`)
+- **`refreshTokenExpiresIn`** now defaults to `30 days` (previously `7 days`)
+- **`advertisedMetadata`** (previously `metadata`) no longer supports changing metadata fields to prevent accidental misconfiguration.
+- **`clientRegistrationDefaultScopes`** (previously `defaultScope`) is now in array format instead of a space-separated string
+- **`consentPage`** is now required
+- **`getConsentHTML`** is removed in favor of the `consentPage` as raw html is not a response type supported by the authorize endpoint in oAuth
+- **`requirePKCE`** is removed as PKCE is required in oAuth2.1
+- **`allowPlainCodeChallengeMethod`** is removed as the `plain` code challenge is considered less secure than the default `S256` method
+- **`getAdditionalUserInfoClaim`** removes the client object as a parameter
+- **`storeClientSecret`** now defaults to `hashed`, or `encrypted` if `disableJwtPlugin: true` (previously `plain`).
+- JWT plugin now is enabled by default. To disable the plugin, set `disableJwtPlugin: true`.
+- Authorization query `code_challenge_method` "S256" must be in caps as described by oAuth 2.1
+
+#### Database
+
+##### Table: `oauthClient`
+
+Previously `oauthApplication`
+
+- If `storeClientSecret` was unset or `plain`, you must hash all the stored `clientSecret` values into its "SHA-256" representation then convert it into base64Url format or use another storage method specified by `storeClientSecret`.
+- `type` field is no longer a required field. Instead, the schema requires `public` of type `boolean`. Migrate with the following rules:
+    - Clients with `type: "public"`: set `type: undefined`, `public: true`, and `clientSecret: undefined`
+    - Clients with `type: "native"`: set `public: true` and `clientSecret: undefined`
+    - Clients with `type: "user-agent-based"`: set `public: true` and `clientSecret: undefined`
+    - Clients with `clientSecret: undefined`: set `public: true`
+- `redirectURLs` renamed to `redirectUris`
+- `metadata` is now stored in database as individual fields instead of a JSON object. Parse the metadata into their respective fields. The OIDC plugin did not utilize this field but this oAuth plugin may utilize them in the future.
+
+##### Table: `oauthAccessToken`
+
+Option 1 (simple):
+
+You may choose to opt-out of this table conversion with minimal impact. By doing so, existing users will simply need to login again. Simply delete the existing table `oauthAccessToken`.
+
+Option 2 (more complex):
+
+- Convert `oauthAccessToken` with `refreshToken` field into a new `oauthRefreshToken` entry.
+```ts
+{
+  token: hashed(refreshToken),
+  expiresAt: refreshTokenExpiresAt,
+  clientId: clientId,
+  scopes: scopes,
+  userId: userId,
+  createdAt: createdAt,
+  updatedAt: updatedAt,
+}
+```
+
+- Keep `oauthAccessToken` but reference new `oauthRefreshToken`.
+```ts
+{
+  token: hashed(accessToken),
+  expiresAt: accessTokenExpiresAt,
+  clientId: clientId,
+  scopes: scopes,
+  refreshId: oauthRefreshToken.id, // `undefined` if no refreshToken
+  createdAt: createdAt,
+  updatedAt: updatedAt,
+}
+```
+
+
+### From [MCP Provider](/docs/plugins/oidc-provider) to this oAuth2.1 provider
+
+The MCP endpoints moved from `/mcp` to the `/oauth2` equivalent.
+
+- `/oauth2/authorize` (previously `/mcp/authorize`)
+- `/oauth2/token` (previously `/mcp/token`)
+- `/oauth2/register` (previously `/mcp/register`)
+- `/mcp/get-session` removed as not oAuth2 compliant, use `/oauth2/introspect` instead
+- `/.well-known/oauth-protected-resource` removed, use the helper `mcpHandler` (or manually with `api.oAuth2introspectVerify`/`verifyAccessToken` and `handleMcpErrors`)
+
+
+### From [API Key](/docs/plugins/api-key)
+
+This oAuth plugin provides additional security benefits over API Keys such as short-lived access tokens, key rotation, and centralized revocation.
+
+While we are currently unable to fully migrate the API Key schema and its functionality at this time, here are some implementation tips to assist in migration:
+
+#### Database
+  - API `permissions` should convert into `scopes`. See [Scopes Vs Permissions](#scopes-vs-permissions) on how to implement this in more detail.
+    - NOTE: the following `scopes` are reserved: 'openid', 'profile', 'name', 'email', 'phone', 'address'.
+
+#### Setup
+  - Register an oAuth client with `scopes`.
+  - Store the `client_id` and `client_secret`(previously `api_key`) in your client's environment.
+
+#### Client
+For user-scoped data:
+  - Request authorization using the `authorization_code` with PKCE flow.
+    - Authorize first at `/oauth2/authorize`.
+    - At the callback, exchange the `code` for `tokens`
+  - Access token can be used to perform scoped actions
+  - If requested with a `offline_access` scope, you use the `refresh_token` to obtain new tokens. Save this in your database alongside the user that authorized it.
+    - Request a new token whenever the `access_token` expires using the `refresh_token` grant at the `/oauth2/token` endpoint
+    - To obtain a JWT-formatted token, you must request using the `resource` parameter again.
+
+For machine-to-machine communication:
+  - Request a token using the `client_credentials` grant at the `/oauth2/token` endpoint
+  - Store the token in memory
+    - Request a new token whenever token expires

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -951,6 +951,48 @@ If you are using "openid" and confidential MCP clients, you cannot disable the J
   <Step>
     ### Handle MCP Errors for your API
 
+    - Using the client `verifyAccessToken` function
+
+    ```ts title="api/[endpoint].ts"
+    import { authClient } from "@/lib/client";
+
+    export const GET = async (req: Request) => {
+      const authorization = req.headers?.get("authorization") ?? undefined;
+      const accessToken = authorization?.startsWith("Bearer ")
+        ? authorization.replace("Bearer ", "")
+        : authorization;
+      const payload = await client.verifyAccessToken(
+        accessToken, {
+          verifyOptions: {
+            issuer: "https://auth.example.com",
+            audience: "https://api.example.com",
+          },
+        }
+      );
+      // ...continue
+    }
+    ```
+
+    - With auth available, use the client `verifyAccessToken` function to automatically determine endpoints
+
+    ```ts title="api/[endpoint].ts"
+    import { auth } from "@/lib/auth";
+    import { authClient } from "@/lib/client";
+
+    export const GET = async (req: Request) => {
+      const authorization = req.headers?.get("authorization") ?? undefined;
+      const accessToken = authorization?.startsWith("Bearer ")
+        ? authorization.replace("Bearer ", "")
+        : authorization;
+      const payload = await authClient.verifyAccessToken(
+        accessToken,
+        undefined,
+        auth,
+      );
+      // ...continue
+    }
+    ```
+
     - Using `mcpHandler` helper
 
     ```ts title="api/[transport]/route.ts"
@@ -995,28 +1037,6 @@ If you are using "openid" and confidential MCP clients, you cannot disable the J
     });
 
     export { handler as GET, handler as POST, handler as DELETE };
-    ```
-
-    - Using the client `verifyAccessToken` function
-
-    ```ts
-    import { authClient } from "./client";
-
-    export const GET = async (req: Request) => {
-      const authorization = req.headers?.get("authorization") ?? undefined;
-      const accessToken = authorization?.startsWith("Bearer ")
-        ? authorization.replace("Bearer ", "")
-        : authorization;
-      const payload = await client.verifyAccessToken(
-        accessToken, {
-          verifyOptions: {
-            issuer: "https://auth.example.com",
-            audience: "https://api.example.com",
-          },
-        }
-      );
-      // ...continue
-    }
     ```
   </Step>
 </Steps>

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -113,10 +113,10 @@ Please report any issues or bugs on [GitHub](https://github.com/better-auth/bett
   <Step>
     ### Create your first client
 
-    Register your first confidential client.
+    Create your first confidential client.
 
     ```ts
-    const client = await auth.api.registerOAuthClient({
+    const client = await auth.api.createOAuthClient({
 			headers,
 			body: {
 				redirect_uris: [redirectUri],

--- a/docs/content/docs/plugins/oidc-provider.mdx
+++ b/docs/content/docs/plugins/oidc-provider.mdx
@@ -3,6 +3,10 @@ title: OIDC Provider
 description: Open ID Connect plugin for Better Auth that allows you to have your own OIDC provider.
 ---
 
+<Callout type="warn">
+This plugin is deprecated in favor of the [OAuth Provider Plugin](/docs/plugins/oauth-provider).
+</Callout>
+
 The **OIDC Provider Plugin** enables you to build and manage your own OpenID Connect (OIDC) provider, granting full control over user authentication without relying on third-party services like Okta or Azure AD. It also allows other services to authenticate users through your OIDC provider.
 
 **Key Features**:

--- a/packages/better-auth/src/client/plugins/index.ts
+++ b/packages/better-auth/src/client/plugins/index.ts
@@ -9,6 +9,7 @@ export * from "../../plugins/additional-fields/client";
 export * from "../../plugins/admin/client";
 export * from "../../plugins/generic-oauth/client";
 export * from "../../plugins/jwt/client";
+export * from "../../plugins/oauth-provider/client";
 export * from "../../plugins/multi-session/client";
 export * from "../../plugins/email-otp/client";
 export * from "../../plugins/one-tap/client";

--- a/packages/better-auth/src/oauth-2.1/types.ts
+++ b/packages/better-auth/src/oauth-2.1/types.ts
@@ -1,0 +1,318 @@
+import type { JWSAlgorithms } from "../plugins/jwt";
+
+/**
+ * Supported grant types of the token endpoint
+ */
+export type GrantType =
+	| "authorization_code"
+	// | "implicit" // NEVER SUPPORT - depreciated in oAuth2.1
+	// | "password" // NEVER SUPPORT - depreciated in oAuth2.1
+	| "client_credentials"
+	| "refresh_token";
+// | "urn:ietf:params:oauth:grant-type:device_code"  // specified in oAuth2.1 but not yet implemented
+// | "urn:ietf:params:oauth:grant-type:jwt-bearer"   // unspecified in oAuth2.1
+// | "urn:ietf:params:oauth:grant-type:saml2-bearer" // unspecified in oAuth2.1
+
+export type AuthMethod =
+	| "client_secret_basic" // Basic header
+	| "client_secret_post"; // POST
+// | "private_key_jwt" // must also add alg_values_supported for that endpoint
+// | "client_secret_jwt" // must also add alg_values_supported for that endpoint
+export type TokenEndpointAuthMethod = AuthMethod | "none"; // Public client support for the token auth endpoint
+export type BearerMethodsSupported = "header" | "body";
+
+/**
+ * Metadata for authentication servers.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc8414#section-2
+ */
+export interface AuthServerMetadata {
+	/**
+	 * The issuer identifier, this is the URL of the provider and can be used to verify
+	 * the `iss` claim in the ID token.
+	 *
+	 * default: the value set for the issuer in the jwt plugin,
+	 * otherwise the base URL of the auth server (e.g. `https://example.com`)
+	 */
+	issuer: string;
+	/**
+	 * The URL of the authorization endpoint.
+	 *
+	 * @default `/oauth2/authorize`
+	 */
+	authorization_endpoint: string;
+	/**
+	 * The URL of the token endpoint.
+	 *
+	 * @default `/oauth2/token`
+	 */
+	token_endpoint: string;
+	/**
+	 * The URL of the jwks_uri endpoint.
+	 *
+	 * For JWKS to work, you must install the `jwt` plugin.
+	 *
+	 * This value is automatically set to `/jwks` if the `jwt` plugin is installed.
+	 *
+	 * @default `/jwks`
+	 */
+	jwks_uri: string;
+	/**
+	 * The URL of the dynamic client registration endpoint.
+	 *
+	 * @default `/oauth2/register`
+	 */
+	registration_endpoint: string;
+	/**
+	 * Supported scopes.
+	 */
+	scopes_supported?: string[];
+	/**
+	 * Supported response types. (for /authorize endpoint)
+	 */
+	response_types_supported: "code"[];
+	/**
+	 * Supported response modes.
+	 *
+	 * `query`: the authorization code is returned in the query string
+	 */
+	response_modes_supported: "query"[];
+	/**
+	 * Supported grant types.
+	 */
+	grant_types_supported: GrantType[];
+	/**
+	 * Supported token endpoint authentication methods.
+	 *
+	 * @default
+	 * ["client_secret_basic", "client_secret_post"]
+	 */
+	token_endpoint_auth_methods_supported?: TokenEndpointAuthMethod[];
+	/**
+	 * Array containing a list of the JWS signing
+	 * algorithms ("alg" values) supported by the token endpoint for
+	 * the signature on the JWT used to authenticate the client at the
+	 * token endpoint for the "private_key_jwt" and "client_secret_jwt"
+	 * authentication methods (see field token_endpoint_auth_methods_supported).
+	 */
+	token_endpoint_auth_signing_alg_values_supported?: JWSAlgorithms[];
+	/**
+	 * URL of a page containing human-readable information
+	 * that developers might want or need to know when using the
+	 * authorization server
+	 */
+	service_documentation?: string;
+	/**
+	 * Languages and scripts supported for the user interface,
+	 * represented as an array of language tag values from BCP 47
+	 * [RFC5646](https://datatracker.ietf.org/doc/html/rfc5646)
+	 */
+	ui_locales_supported?: string[];
+	/**
+	 * URL that the authorization server provides to the
+	 * person registering the client to read about the authorization
+	 * server's requirements on how the client can use the data provided
+	 * by the authorization server.
+	 */
+	op_policy_uri?: string;
+	/**
+	 * URL that the authorization server provides to the
+	 * person registering the client to read about the authorization
+	 * server's terms of service.
+	 */
+	op_tos_uri?: string;
+	/**
+	 * URL of the authorization server's OAuth 2.0 revocation
+	 * endpoint [RFC7009](https://datatracker.ietf.org/doc/html/rfc7009)
+	 */
+	revocation_endpoint?: string;
+	/**
+	 * Array containing a list of client authentication
+	 * methods supported by this revocation endpoint
+	 *
+	 * @default
+	 * ["client_secret_basic", "client_secret_post"]
+	 */
+	revocation_endpoint_auth_methods_supported?: AuthMethod[];
+	/**
+	 * Array containing a list of the JWS signing
+	 * algorithms ("alg" values) supported by the revocation endpoint for
+	 * the signature on the JWT used to authenticate the client at the
+	 * token endpoint for the "private_key_jwt" and "client_secret_jwt"
+	 * authentication methods (see field revocation_endpoint_auth_methods_supported).
+	 */
+	revocation_endpoint_auth_signing_alg_values_supported?: JWSAlgorithms[];
+	/**
+	 * URL of the authorization server's OAuth 2.0
+	 * introspection endpoint [RFC7662](https://datatracker.ietf.org/doc/html/rfc7662)
+	 */
+	introspection_endpoint?: string;
+	/**
+	 * Array containing a list of client authentication
+	 * methods supported by this introspection endpoint
+	 *
+	 * @default
+	 * ["client_secret_basic", "client_secret_post"]
+	 */
+	introspection_endpoint_auth_methods_supported?: AuthMethod[];
+	/**
+	 * Array containing a list of the JWS signing
+	 * algorithms ("alg" values) supported by the introspection endpoint
+	 * used to authenticate the client at the token endpoint for
+	 * the "private_key_jwt" and "client_secret_jwt" authentication methods
+	 * (see field introspection_endpoint_auth_methods_supported).
+	 */
+	introspection_endpoint_auth_signing_alg_values_supported?: JWSAlgorithms[];
+	/**
+	 * Supported code challenge methods.
+	 *
+	 * @default ["S256"]
+	 */
+	code_challenge_methods_supported: "S256"[];
+}
+
+/**
+ * Metadata returned by the openid-configuration endpoint:
+ * /.well-known/openid-configuration
+ *
+ * NOTE: Url structure is different by appending to the end
+ * of the url instead of the base.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc8414#section-5
+ */
+export interface OIDCMetadata extends AuthServerMetadata {
+	/**
+	 * The URL of the userinfo endpoint.
+	 *
+	 * @default `/oauth2/userinfo`
+	 */
+	userinfo_endpoint: string;
+	/**
+	 * acr_values supported.
+	 *
+	 * - `urn:mace:incommon:iap:silver`: Silver level of assurance
+	 * - `urn:mace:incommon:iap:bronze`: Bronze level of assurance
+	 *
+	 * Determination of acr_value is considered bronze by default.
+	 * Silver level determination coming soon.
+	 *
+	 * @default
+	 * ["urn:mace:incommon:iap:bronze"]
+	 * @see https://incommon.org/federation/attributes.html
+	 */
+	acr_values_supported: string[];
+	/**
+	 * Supported subject types.
+	 *
+	 * pairwise: the subject identifier is unique to the client
+	 * public: the subject identifier is unique to the server
+	 *
+	 * only `public` is supported.
+	 */
+	subject_types_supported: "public"[];
+	/**
+	 * Supported ID token signing algorithms.
+	 *
+	 * Automatically uses the same algorithm used in the JWK Plugin.
+	 * Support for symmetric algorithms is strictly prohibited
+	 * to sharing key vulnerabilities!
+	 *
+	 * @default
+	 * ["EdDSA"]
+	 */
+	id_token_signing_alg_values_supported: JWSAlgorithms[];
+	/**
+	 * Supported claims.
+	 *
+	 * @default
+	 * ["sub", "iss", "aud", "exp", "nbf", "iat", "jti", "email", "email_verified", "name", "family_name", "given_name", "sid", "scope", "azp"]
+	 */
+	claims_supported: string[];
+}
+
+/**
+ * OAuth 2.0 Dynamic Client Registration Schema
+ *
+ * Current spec is based on OAuth 2.0, but shall use
+ * OAuth 2.1 restrictions.
+ *
+ * https://datatracker.ietf.org/doc/html/rfc7591#section-2
+ */
+export interface OAuthClient {
+	client_id: string;
+	client_secret?: string;
+	client_secret_expires_at?: number;
+	scope?: string;
+	//---- Recommended client data ----//
+	user_id?: string;
+	client_id_issued_at?: number;
+	//---- UI Metadata ----//
+	client_name?: string;
+	client_uri?: string;
+	logo_uri?: string;
+	contacts?: string[];
+	tos_uri?: string;
+	policy_uri?: string;
+	//---- Jwks (only one can be used) ----//
+	jwks?: string[];
+	jwks_uri?: string;
+	//---- User Software Identifiers ----//
+	software_id?: string;
+	software_version?: string;
+	software_statement?: string;
+	//---- Authentication Metadata ----//
+	redirect_uris?: string[];
+	token_endpoint_auth_method?:
+		| "none"
+		| "client_secret_basic"
+		| "client_secret_post";
+	grant_types?: GrantType[];
+	response_types?: "code"[];
+	// | "token" // NEVER SUPPORT - depreciated in oAuth2.1
+	//---- RFC6749 Spec ----//
+	public?: boolean;
+	type?: "web" | "native" | "user-agent-based";
+	//---- Not Part of RFC7591 Spec ----//
+	disabled?: boolean;
+	skip_consent?: boolean;
+	//---- All other metadata ----//
+	[key: string]: any;
+}
+
+/**
+ * Resource metadata server as defined by RFC 9728
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc9728#Terminology
+ */
+export interface ResourceServerMetadata {
+	/**
+	 * The protected resource's resource identifier,
+	 * which is a URL that uses the https scheme and
+	 * has no fragment component. It also SHOULD NOT
+	 * include a query component, but it may if
+	 * necessary.
+	 *
+	 * This SHOULD match the aud field of your JWT.
+	 */
+	resource: string;
+	/**
+	 * Each server should pertain to one issuer.
+	 *
+	 * MCP requires at least one server.
+	 *
+	 * @default [`${baseUrl}/.well-known/oauth-authorization-server`]
+	 */
+	authorization_servers?: string[];
+	jwks_uri?: string;
+	scopes_supported?: string[];
+	bearer_methods_supported?: BearerMethodsSupported[];
+	resource_signing_alg_values_supported?: JWSAlgorithms[];
+	resource_name?: string;
+	resource_documentation?: string;
+	resource_policy_uri?: string;
+	resource_tos_uri?: string;
+	tls_client_certificate_bound_access_tokens?: boolean;
+	authorization_details_types_supported?: string;
+	dpop_signing_alg_values_supported?: JWSAlgorithms[];
+	dpop_bound_access_tokens_required?: boolean;
+}

--- a/packages/better-auth/src/plugins/index.ts
+++ b/packages/better-auth/src/plugins/index.ts
@@ -14,6 +14,7 @@ export * from "./multi-session";
 export * from "./email-otp";
 export * from "./one-tap";
 export * from "./oauth-proxy";
+export * from "./oauth-provider";
 export * from "./custom-session";
 export * from "./open-api";
 export * from "./oidc-provider";

--- a/packages/better-auth/src/plugins/mcp/index.ts
+++ b/packages/better-auth/src/plugins/mcp/index.ts
@@ -105,6 +105,12 @@ export const getMCPProtectedResourceMetadata = (
 	};
 };
 
+/**
+ * MCP plugin for Better Auth.
+ *
+ * @see https://better-auth.com/docs/plugins/mcp
+ * @deprecated Use [oauthProvider](../oauth-provider/index.ts) instead
+ */
 export const mcp = (options: MCPOptions) => {
 	const opts = {
 		codeExpiresIn: 600,

--- a/packages/better-auth/src/plugins/oauth-provider/authorize.test.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/authorize.test.ts
@@ -39,7 +39,7 @@ describe("oauth authorize - unauthenticated", async () => {
 	const redirectUri = `${rpBaseUrl}/api/auth/oauth2/callback/${providerId}`;
 	// Registers a confidential client application to work with
 	beforeAll(async () => {
-		const response = await auth.api.registerOAuthClient({
+		const response = await auth.api.createOAuthClient({
 			headers,
 			body: {
 				redirect_uris: [redirectUri],
@@ -120,7 +120,7 @@ describe("oauth authorize - authenticated", async () => {
 	const redirectUri = `${rpBaseUrl}/api/auth/oauth2/callback/${providerId}`;
 	// Registers a confidential client application to work with
 	beforeAll(async () => {
-		const response = await auth.api.registerOAuthClient({
+		const response = await auth.api.createOAuthClient({
 			headers,
 			body: {
 				redirect_uris: [redirectUri],

--- a/packages/better-auth/src/plugins/oauth-provider/authorize.test.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/authorize.test.ts
@@ -1,0 +1,166 @@
+import { beforeAll, describe, it, expect } from "vitest";
+import { oauthProvider } from "./oauth";
+import type { OAuthClient } from "../../oauth-2.1/types";
+import { createAuthClient } from "../../client";
+import { getTestInstance } from "../../test-utils/test-instance";
+import { jwt } from "../jwt";
+import { oauthProviderClient } from "./client";
+import { createAuthorizationURL } from "../../oauth2";
+import { generateRandomString } from "../../crypto";
+
+describe("oauth authorize - unauthenticated", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const rpBaseUrl = "http://localhost:5000";
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+			jwt(),
+		],
+	});
+	const { headers } = await signInWithTestUser();
+	const unauthenticatedClient = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: {
+			customFetchImpl,
+		},
+	});
+
+	let oauthClient: OAuthClient | null;
+	const providerId = "test";
+	const redirectUri = `${rpBaseUrl}/api/auth/oauth2/callback/${providerId}`;
+	// Registers a confidential client application to work with
+	beforeAll(async () => {
+		const response = await auth.api.registerOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [redirectUri],
+				skip_consent: true,
+			},
+		});
+		expect(response?.client_id).toBeDefined();
+		expect(response?.user_id).toBeDefined();
+		expect(response?.client_secret).toBeDefined();
+		expect(response?.redirect_uris).toEqual([redirectUri]);
+		oauthClient = response;
+	});
+
+	it("should always redirect to /login because user is not logged in", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+		const authUrl = await createAuthorizationURL({
+			id: providerId,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+			},
+			redirectURI: redirectUri,
+			state: "123",
+			scopes: ["openid"],
+			responseType: "code",
+			codeVerifier: generateRandomString(64),
+			authorizationEndpoint: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
+		});
+
+		let loginRedirectUrl = "";
+		await unauthenticatedClient.$fetch(authUrl.toString(), {
+			onError(context) {
+				loginRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		expect(loginRedirectUrl).toContain("/login");
+		expect(loginRedirectUrl).toContain("response_type=code");
+		expect(loginRedirectUrl).toContain(`client_id=${oauthClient.client_id}`);
+		expect(loginRedirectUrl).toContain("scope=openid");
+		expect(loginRedirectUrl).toContain(
+			`redirect_uri=${encodeURIComponent(redirectUri)}`,
+		);
+	});
+});
+
+describe("oauth authorize - authenticated", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const rpBaseUrl = "http://localhost:5000";
+
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+			jwt(),
+		],
+	});
+	const { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: {
+			customFetchImpl,
+			headers,
+		},
+	});
+
+	let oauthClient: OAuthClient | null;
+	const providerId = "test";
+	const redirectUri = `${rpBaseUrl}/api/auth/oauth2/callback/${providerId}`;
+	// Registers a confidential client application to work with
+	beforeAll(async () => {
+		const response = await auth.api.registerOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [redirectUri],
+				skip_consent: true,
+			},
+		});
+		expect(response?.client_id).toBeDefined();
+		expect(response?.user_id).toBeDefined();
+		expect(response?.client_secret).toBeDefined();
+		expect(response?.redirect_uris).toEqual([redirectUri]);
+		oauthClient = response;
+	});
+
+	it("should authorize - prompt undefined, response code, state set, with codeVerifier", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+		const codeVerifier = generateRandomString(64);
+		const authUrl = await createAuthorizationURL({
+			id: providerId,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+			},
+			redirectURI: redirectUri,
+			state: "123",
+			scopes: ["openid"],
+			responseType: "code",
+			authorizationEndpoint: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
+			codeVerifier,
+		});
+
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		expect(callbackRedirectUrl).toContain(redirectUri);
+		expect(callbackRedirectUrl).toContain(`code=`);
+		expect(callbackRedirectUrl).toContain(`state=123`);
+	});
+});

--- a/packages/better-auth/src/plugins/oauth-provider/authorize.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/authorize.ts
@@ -1,0 +1,352 @@
+import { APIError } from "better-call";
+import type { GenericEndpointContext } from "@better-auth/core";
+import { getSessionFromCtx } from "../../api";
+import type {
+	OAuthAuthorizationQuery,
+	OAuthConsent,
+	OAuthOptions,
+	VerificationValue,
+} from "./types";
+import { generateRandomString } from "../../crypto";
+import { getClient, storeToken } from "./utils";
+
+/**
+ * Formats an error url
+ */
+export function formatErrorURL(
+	url: string,
+	error: string,
+	description: string,
+	state?: string,
+) {
+	const searchParams = new URLSearchParams({
+		error,
+		error_description: description,
+	});
+	state && searchParams.append("state", state);
+	return `${url}${url.includes("?") ? "&" : "?"}${searchParams.toString()}`;
+}
+
+const handleRedirect = (ctx: GenericEndpointContext, uri: string) => {
+	const acceptJson = ctx.request?.headers
+		.get("accept")
+		?.includes("application/json");
+	if (acceptJson) {
+		return ctx.json({
+			redirect: true,
+			url: uri.toString(),
+		});
+	} else {
+		throw ctx.redirect(uri);
+	}
+};
+
+/**
+ * Error page url if redirect_uri has not been verified yet
+ * Generates Url for custom error page
+ */
+function getErrorURL(
+	ctx: GenericEndpointContext,
+	error: string,
+	description: string,
+) {
+	const baseURL =
+		ctx.context.options.onAPIError?.errorURL || `${ctx.context.baseURL}/error`;
+	const formattedURL = formatErrorURL(baseURL, error, description);
+	return formattedURL;
+}
+
+export async function authorizeEndpoint(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions,
+) {
+	// Grant type must include authorization_code to use this endpoint
+	if (opts.grantTypes && !opts.grantTypes.includes("authorization_code")) {
+		throw new APIError("NOT_FOUND");
+	}
+
+	if (!ctx.request) {
+		throw new APIError("UNAUTHORIZED", {
+			error_description: "request not found",
+			error: "invalid_request",
+		});
+	}
+
+	// Check request
+	const query: OAuthAuthorizationQuery = ctx.query;
+	if (!query.client_id) {
+		throw ctx.redirect(
+			getErrorURL(ctx, "invalid_client", "client_id is required"),
+		);
+	}
+
+	if (!query.response_type) {
+		throw ctx.redirect(
+			getErrorURL(ctx, "invalid_request", "response_type is required"),
+		);
+	}
+
+	if (!(query.response_type === "code")) {
+		throw ctx.redirect(
+			getErrorURL(
+				ctx,
+				"unsupported_response_type",
+				"unsupported response type",
+			),
+		);
+	}
+
+	// Check client
+	const client = await getClient(ctx, opts, query.client_id);
+	if (!client) {
+		throw ctx.redirect(
+			getErrorURL(ctx, "invalid_client", "client_id is required"),
+		);
+	}
+	if (client.disabled) {
+		throw ctx.redirect(
+			getErrorURL(ctx, "client_disabled", "client is disabled"),
+		);
+	}
+	const redirectUri = client.redirectUris?.find(
+		(url) => url === query.redirect_uri,
+	);
+	if (!redirectUri || !query.redirect_uri) {
+		throw ctx.redirect(
+			getErrorURL(ctx, "invalid_redirect", "invalid redirect uri"),
+		);
+	}
+
+	const requestScope = query.scope?.split(" ").filter((s) => s) ?? [];
+	const invalidScopes = requestScope.filter((scope) => {
+		// invalid in scopes list
+		return (
+			!opts.scopes?.includes(scope) ||
+			// offline access must be requested through PKCE
+			(scope === "offline_access" &&
+				(query.code_challenge_method !== "S256" || !query.code_challenge))
+		);
+	});
+	if (invalidScopes.length) {
+		throw ctx.redirect(
+			formatErrorURL(
+				query.redirect_uri,
+				"invalid_scope",
+				`The following scopes are invalid: ${invalidScopes.join(", ")}`,
+				query.state,
+			),
+		);
+	}
+
+	if (!query.code_challenge || !query.code_challenge_method) {
+		throw ctx.redirect(
+			formatErrorURL(
+				query.redirect_uri,
+				"invalid_request",
+				"pkce is required",
+				query.state,
+			),
+		);
+	}
+
+	// Check code challenges
+	const codeChallengesSupported = ["S256"];
+	if (!codeChallengesSupported.includes(query.code_challenge_method)) {
+		throw ctx.redirect(
+			formatErrorURL(
+				query.redirect_uri,
+				"invalid_request",
+				"invalid code_challenge method",
+				query.state,
+			),
+		);
+	}
+
+	// Check for session
+	const session = await getSessionFromCtx(ctx);
+	if (!session || query.prompt === "login") {
+		const { name: cookieName, attributes: cookieAttributes } =
+			ctx.context.createAuthCookie("oauth_login_prompt");
+		await ctx.setSignedCookie(
+			cookieName,
+			JSON.stringify(ctx.query),
+			ctx.context.secret,
+			cookieAttributes,
+		);
+		const reqestUrl = new URL(ctx.request.url);
+		return handleRedirect(ctx, `${opts.loginPage}${reqestUrl.search}`);
+	}
+
+	// Force consent screen
+	if (query.prompt === "consent") {
+		return redirectWithConsentCode(ctx, opts, {
+			query,
+			clientId: client.clientId,
+			userId: session.user.id,
+			sessionId: session.session.id,
+			scopes: requestScope.join(" "),
+		});
+	}
+
+	// Can skip consent (unless forced by prompt above)
+	if (client.skipConsent) {
+		return redirectWithAuthorizationCode(ctx, opts, {
+			query,
+			clientId: client.clientId,
+			userId: session.user.id,
+			sessionId: session.session.id,
+			scopes: requestScope.join(" "),
+		});
+	}
+	const consent = await ctx.context.adapter
+		.findOne<OAuthConsent>({
+			model: opts.schema?.oauthConsent?.modelName ?? "oauthConsent",
+			where: [
+				{
+					field: "clientId",
+					value: client.clientId,
+				},
+				{
+					field: "userId",
+					value: session.user.id,
+				},
+			],
+		})
+		.then((res) => {
+			if (!res) return undefined;
+			return {
+				...res,
+				scopes: (res.scopes as unknown as string)?.split(" "),
+			} as OAuthConsent;
+		});
+
+	if (!consent || !requestScope.every((val) => consent.scopes.includes(val))) {
+		return redirectWithConsentCode(ctx, opts, {
+			query,
+			clientId: client.clientId,
+			userId: session.user.id,
+			sessionId: session.session.id,
+			scopes: requestScope.join(" "),
+		});
+	}
+
+	return redirectWithAuthorizationCode(ctx, opts, {
+		query,
+		clientId: client.clientId,
+		userId: session.user.id,
+		sessionId: session.session.id,
+		scopes: requestScope.join(" "),
+	});
+}
+
+async function redirectWithAuthorizationCode(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions,
+	verificationValue: {
+		query: OAuthAuthorizationQuery;
+		clientId: string;
+		userId: string;
+		sessionId: string;
+		scopes: string;
+	},
+) {
+	const code = generateRandomString(32, "a-z", "A-Z", "0-9");
+	const now = Math.floor(Date.now() / 1000);
+	const expiresAt = now + (opts.codeExpiresIn ?? 600);
+
+	await ctx.context.internalAdapter.createVerificationValue(
+		{
+			identifier: await storeToken(
+				opts.storeTokens,
+				code,
+				"authorization_code",
+			),
+			createdAt: new Date(now * 1000),
+			expiresAt: new Date(expiresAt * 1000),
+			value: JSON.stringify({
+				type: "authorization_code",
+				clientId: verificationValue.clientId,
+				userId: verificationValue.userId,
+				sessionId: verificationValue?.sessionId,
+				redirectUri: verificationValue.query.redirect_uri,
+				scopes: verificationValue.scopes,
+				...(verificationValue.query.state !== undefined
+					? { state: verificationValue.query.state }
+					: {}),
+				codeChallenge: verificationValue.query.code_challenge,
+				codeChallengeMethod: verificationValue.query.code_challenge_method,
+				nonce: verificationValue.query.nonce,
+			} satisfies VerificationValue),
+		},
+		ctx,
+	);
+
+	const redirectUriWithCode = new URL(verificationValue.query.redirect_uri);
+	redirectUriWithCode.searchParams.set("code", code);
+	if (verificationValue.query.state) {
+		redirectUriWithCode.searchParams.set(
+			"state",
+			verificationValue.query.state,
+		);
+	}
+	return handleRedirect(ctx, redirectUriWithCode.toString());
+}
+
+async function redirectWithConsentCode(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions,
+	verificationValue: {
+		query: OAuthAuthorizationQuery;
+		clientId: string;
+		userId: string;
+		sessionId: string;
+		scopes: string;
+	},
+) {
+	const code = generateRandomString(32, "a-z", "A-Z", "0-9");
+	const iat = Math.floor(Date.now() / 1000);
+	const exp = iat + (opts.codeExpiresIn ?? 600);
+
+	await ctx.context.internalAdapter.createVerificationValue(
+		{
+			identifier: await storeToken(
+				opts.storeTokens,
+				code,
+				"authorization_code",
+			),
+			createdAt: new Date(iat * 1000),
+			expiresAt: new Date(exp * 1000),
+			value: JSON.stringify({
+				type: "consent",
+				clientId: verificationValue.clientId,
+				userId: verificationValue.userId,
+				sessionId: verificationValue.sessionId,
+				redirectUri: verificationValue.query.redirect_uri,
+				scopes: verificationValue.scopes,
+				state: verificationValue.query.state,
+				codeChallenge: verificationValue.query.code_challenge,
+				codeChallengeMethod: verificationValue.query.code_challenge_method,
+				nonce: verificationValue.query.nonce,
+			} satisfies VerificationValue),
+		},
+		ctx,
+	);
+
+	const { name: cookieName, attributes: cookieAttributes } =
+		ctx.context.createAuthCookie("oauth_consent_prompt");
+	await ctx.setSignedCookie(
+		cookieName,
+		code,
+		ctx.context.secret,
+		cookieAttributes,
+	);
+
+	const params = new URLSearchParams({
+		client_id: verificationValue.clientId,
+		scope: verificationValue.scopes,
+		state: verificationValue.query.state,
+	});
+	const consentUri = `${opts.consentPage}?${params.toString()}`;
+
+	return handleRedirect(ctx, consentUri);
+}

--- a/packages/better-auth/src/plugins/oauth-provider/client.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/client.ts
@@ -1,8 +1,22 @@
 import type { oauthProvider } from "./oauth";
 import type { BetterAuthClientPlugin } from "../../types";
 import { verifyAccessToken } from "./verify";
-import type { JWTVerifyOptions } from "jose";
+import type { JWTPayload, JWTVerifyOptions } from "jose";
 import { handleMcpErrors } from "./mcp";
+import type { Auth } from "../../auth";
+import { getJwtPlugin, getOAuthProviderPlugin } from "./utils";
+
+export const oauthProviderClient = () => {
+	return {
+		id: "oauth-provider-client",
+		$InferServerPlugin: {} as ReturnType<typeof oauthProvider>,
+		getActions() {
+			return {
+				verifyAccessToken: _verifyAccessToken,
+			};
+		},
+	} satisfies BetterAuthClientPlugin;
+};
 
 interface VerifyAccessTokenRemote {
 	/** Full url of the introspect endpoint. Should end with `/oauth2/introspect` */
@@ -19,33 +33,102 @@ interface VerifyAccessTokenRemote {
 	force?: boolean;
 }
 
-export const oauthProviderClient = () => {
-	return {
-		id: "oauth-provider-client",
-		$InferServerPlugin: {} as ReturnType<typeof oauthProvider>,
-		getActions() {
-			return {
-				verifyAccessToken: async (
-					token: string,
-					opts: {
-						/** Verify options */
-						verifyOptions: JWTVerifyOptions &
-							Required<Pick<JWTVerifyOptions, "audience" | "issuer">>;
-						/** Scopes to additionally verify. Token must include all but not exact. */
-						scopes?: string[];
-						/** Required to verify access token locally */
-						jwksUrl?: string;
-						/** If provided, can verify a token remotely */
-						remoteVerify?: VerifyAccessTokenRemote;
-					},
-				) => {
-					try {
-						return await verifyAccessToken(token, opts);
-					} catch (error) {
-						handleMcpErrors(error, opts.verifyOptions.audience);
-					}
-				},
-			};
-		},
-	} satisfies BetterAuthClientPlugin;
-};
+// Without auth available
+async function _verifyAccessToken(
+	token: string,
+	opts: {
+		verifyOptions: JWTVerifyOptions &
+			Required<Pick<JWTVerifyOptions, "audience" | "issuer">>;
+		scopes?: string[];
+		jwksUrl?: string;
+		remoteVerify?: VerifyAccessTokenRemote;
+	},
+): Promise<JWTPayload>;
+// With auth available
+async function _verifyAccessToken(
+	token: string,
+	opts:
+		| {
+				verifyOptions?: JWTVerifyOptions;
+				scopes?: string[];
+				jwksUrl?: string;
+				remoteVerify?: Omit<VerifyAccessTokenRemote, "introspectUrl"> &
+					Partial<Pick<VerifyAccessTokenRemote, "introspectUrl">>;
+		  }
+		| undefined,
+	auth: Auth,
+): Promise<JWTPayload>;
+
+async function _verifyAccessToken(
+	token: string,
+	opts?: {
+		/** Verify options */
+		verifyOptions?: JWTVerifyOptions;
+		/** Scopes to additionally verify. Token must include all but not exact. */
+		scopes?: string[];
+		/** Required to verify access token locally */
+		jwksUrl?: string;
+		/** If provided, can verify a token remotely */
+		remoteVerify?: Omit<VerifyAccessTokenRemote, "introspectUrl"> &
+			Partial<Pick<VerifyAccessTokenRemote, "introspectUrl">>;
+	},
+	auth?: Auth,
+) {
+	const oauthProvider = auth ? getOAuthProviderPlugin(auth) : undefined;
+	const oauthProviderOptions = oauthProvider?.options;
+	const jwtPlugin =
+		auth && !oauthProviderOptions?.disableJwtPlugin
+			? getJwtPlugin(auth)
+			: undefined;
+	const jwtPluginOptions = jwtPlugin?.options;
+	const authServerBaseUrl = auth?.options.baseURL;
+	const authServerBasePath = auth?.options.basePath;
+
+	const audience =
+		opts?.verifyOptions?.audience ??
+		jwtPluginOptions?.jwt?.audience ??
+		authServerBaseUrl;
+	const issuer =
+		opts?.verifyOptions?.issuer ??
+		jwtPluginOptions?.jwt?.issuer ??
+		authServerBaseUrl;
+	if (!audience) {
+		throw Error("please define opts.verifyOptions.audience");
+	}
+	if (!issuer) {
+		throw Error("please define opts.verifyOptions.issuer");
+	}
+
+	const jwksUrl =
+		opts?.jwksUrl ??
+		jwtPluginOptions?.jwks?.remoteUrl ??
+		(authServerBaseUrl
+			? `${authServerBaseUrl + (authServerBasePath ?? "")}/jwks`
+			: undefined);
+	const introspectUrl =
+		opts?.remoteVerify?.introspectUrl ??
+		(authServerBaseUrl
+			? `${authServerBaseUrl}${authServerBasePath ?? ""}/oauth2/introspect`
+			: undefined);
+
+	try {
+		return await verifyAccessToken(token, {
+			...opts,
+			jwksUrl,
+			verifyOptions: {
+				...opts?.verifyOptions,
+				audience,
+				issuer,
+			},
+			remoteVerify:
+				opts?.remoteVerify && introspectUrl
+					? {
+							introspectUrl,
+							...opts.remoteVerify,
+						}
+					: undefined,
+		});
+	} catch (error) {
+		handleMcpErrors(error, audience);
+	}
+}

--- a/packages/better-auth/src/plugins/oauth-provider/client.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/client.ts
@@ -1,9 +1,51 @@
 import type { oauthProvider } from "./oauth";
 import type { BetterAuthClientPlugin } from "../../types";
+import { verifyAccessToken } from "./verify";
+import type { JWTVerifyOptions } from "jose";
+import { handleMcpErrors } from "./mcp";
+
+interface VerifyAccessTokenRemote {
+	/** Full url of the introspect endpoint. Should end with `/oauth2/introspect` */
+	introspectUrl: string;
+	/** Client Secret */
+	clientId: string;
+	/** Client Secret */
+	clientSecret: string;
+	/**
+	 * Forces remote verification of a token.
+	 * This ensures attached session (if applicable)
+	 * is also still active.
+	 */
+	force?: boolean;
+}
 
 export const oauthProviderClient = () => {
 	return {
 		id: "oauth-provider-client",
 		$InferServerPlugin: {} as ReturnType<typeof oauthProvider>,
+		getActions() {
+			return {
+				verifyAccessToken: async (
+					token: string,
+					opts: {
+						/** Verify options */
+						verifyOptions: JWTVerifyOptions &
+							Required<Pick<JWTVerifyOptions, "audience" | "issuer">>;
+						/** Scopes to additionally verify. Token must include all but not exact. */
+						scopes?: string[];
+						/** Required to verify access token locally */
+						jwksUrl?: string;
+						/** If provided, can verify a token remotely */
+						remoteVerify?: VerifyAccessTokenRemote;
+					},
+				) => {
+					try {
+						return await verifyAccessToken(token, opts);
+					} catch (error) {
+						handleMcpErrors(error, opts.verifyOptions.audience);
+					}
+				},
+			};
+		},
 	} satisfies BetterAuthClientPlugin;
 };

--- a/packages/better-auth/src/plugins/oauth-provider/client.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/client.ts
@@ -1,0 +1,9 @@
+import type { oauthProvider } from "./oauth";
+import type { BetterAuthClientPlugin } from "../../types";
+
+export const oauthProviderClient = () => {
+	return {
+		id: "oauth-provider-client",
+		$InferServerPlugin: {} as ReturnType<typeof oauthProvider>,
+	} satisfies BetterAuthClientPlugin;
+};

--- a/packages/better-auth/src/plugins/oauth-provider/consent.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/consent.ts
@@ -1,0 +1,136 @@
+import { APIError } from "../../api";
+import type { OAuthConsent, OAuthOptions, VerificationValue } from "./types";
+import type { GenericEndpointContext } from "@better-auth/core";
+import type { Verification } from "../../types";
+import { generateRandomString } from "../../crypto";
+import { formatErrorURL } from "./authorize";
+import { storeToken } from "./utils";
+
+export async function consentEndpoint(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions,
+) {
+	const { name: cookieName } = ctx.context.createAuthCookie(
+		"oauth_consent_prompt",
+	);
+	const storedCode = await ctx.getSignedCookie(cookieName, ctx.context.secret);
+	ctx.setCookie(cookieName, "", {
+		maxAge: 0,
+	});
+	if (!storedCode) {
+		throw new APIError("UNAUTHORIZED", {
+			error_description: "No consent prompt found",
+			error: "invalid_request",
+		});
+	}
+
+	const verification = await ctx.context.internalAdapter
+		.findVerificationValue(
+			await storeToken(opts.storeTokens, storedCode, "authorization_code"),
+		)
+		.then((val) => {
+			if (!val) return null;
+			let parsedValue: VerificationValue | undefined;
+			if (val.value) {
+				try {
+					parsedValue = JSON.parse(val.value);
+				} catch (err) {
+					throw new APIError("UNAUTHORIZED", {
+						message: "invalid verification value",
+					});
+				}
+			}
+			return {
+				...val,
+				value: parsedValue,
+			} as Omit<Verification, "value"> & { value?: VerificationValue };
+		});
+	const verificationValue = verification?.value;
+
+	// Check verification
+	if (!verification) {
+		throw new APIError("UNAUTHORIZED", {
+			error_description: "Invalid code",
+			error: "invalid_request",
+		});
+	}
+	if (verification.expiresAt < new Date()) {
+		throw new APIError("UNAUTHORIZED", {
+			error_description: "Code expired",
+			error: "invalid_request",
+		});
+	}
+
+	// Check verification value
+	if (!verificationValue) {
+		throw new APIError("UNAUTHORIZED", {
+			error_description: "missing verification value content",
+			error: "invalid_verification",
+		});
+	}
+	if (verificationValue.type !== "consent") {
+		throw new APIError("UNAUTHORIZED", {
+			error_description: "incorrect token type",
+			error: "invalid_request",
+		});
+	}
+	if (!verificationValue.redirectUri) {
+		throw new APIError("UNAUTHORIZED", {
+			error_description: "Missing redirect uri",
+			error: "invalid_request",
+		});
+	}
+
+	// Consent not accepted (ensure it's strictly boolean true)
+	const accepted = ctx.body.accept === true;
+	if (!accepted) {
+		await ctx.context.internalAdapter.deleteVerificationValue(verification.id);
+		return ctx.json({
+			redirect_uri: formatErrorURL(
+				verificationValue.redirectUri,
+				"access_denied",
+				"User denied access",
+				verificationValue.state,
+			),
+		});
+	}
+
+	// Consent accepted
+	const code = generateRandomString(32, "a-z", "A-Z", "0-9");
+	const iat = Math.floor(Date.now() / 1000);
+	const exp = iat + (opts.codeExpiresIn ?? 600);
+
+	await ctx.context.internalAdapter.updateVerificationValue(verification.id, {
+		value: JSON.stringify({
+			...verificationValue,
+			type: "authorization_code",
+		}),
+		identifier: await storeToken(opts.storeTokens, code, "authorization_code"),
+		expiresAt: new Date(exp * 1000),
+	});
+	const consent: OAuthConsent = {
+		clientId: verificationValue.clientId,
+		userId: verificationValue.userId,
+		scopes: verificationValue.scopes.split(" "),
+		consentGiven: true,
+		createdAt: new Date(iat * 1000),
+		updatedAt: new Date(iat * 1000),
+	};
+	await ctx.context.adapter.create({
+		model: opts.schema?.oauthConsent?.modelName ?? "oauthConsent",
+		data: {
+			...consent,
+			scopes: consent.scopes.join(" "),
+		},
+	});
+	const redirectUri = new URL(verificationValue.redirectUri ?? opts.loginPage);
+	redirectUri.searchParams.set("code", code);
+	if (verificationValue.state) {
+		redirectUri.searchParams.set("state", verificationValue.state);
+	}
+
+	// Redirect back to application
+	return ctx.json({
+		redirect_uri: redirectUri.toString(),
+	});
+}

--- a/packages/better-auth/src/plugins/oauth-provider/index.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/index.ts
@@ -4,7 +4,6 @@ export {
 	oauthProviderOpenIdConfigMetadata,
 	oauthProviderProtectedResourceMetadata,
 } from "./metadata";
-export { verifyAccessToken } from "./verify";
-export { mcpHandler, handleMcpErrors } from "./mcp";
+export { mcpHandler } from "./mcp";
 export { oauthProvider } from "./oauth";
 export type * from "./types";

--- a/packages/better-auth/src/plugins/oauth-provider/index.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/index.ts
@@ -1,0 +1,10 @@
+export { authServerMetadata, oidcServerMetadata } from "./metadata";
+export {
+	oauthProviderAuthServerMetadata,
+	oauthProviderOpenIdConfigMetadata,
+	oauthProviderProtectedResourceMetadata,
+} from "./metadata";
+export { verifyAccessToken } from "./verify";
+export { mcpHandler, handleMcpErrors } from "./mcp";
+export { oauthProvider } from "./oauth";
+export type * from "./types";

--- a/packages/better-auth/src/plugins/oauth-provider/introspect.test.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/introspect.test.ts
@@ -141,7 +141,7 @@ describe("oauth introspect", async () => {
 
 	// Registers a confidential client application to work with
 	beforeAll(async () => {
-		const response = await auth.api.registerOAuthClient({
+		const response = await auth.api.createOAuthClient({
 			headers,
 			body: {
 				redirect_uris: [redirectUri],
@@ -437,7 +437,7 @@ describe("oauth introspect - config", async () => {
 			},
 		});
 
-		const registeredClient = await auth.api.registerOAuthClient({
+		const registeredClient = await auth.api.createOAuthClient({
 			headers,
 			body: {
 				redirect_uris: [redirectUri],

--- a/packages/better-auth/src/plugins/oauth-provider/introspect.test.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/introspect.test.ts
@@ -1,0 +1,570 @@
+import { beforeAll, describe, it, expect } from "vitest";
+import { getTestInstance } from "../../test-utils/test-instance";
+import { jwt } from "../jwt";
+import { oauthProvider } from "./oauth";
+import type { OAuthOptions } from "./types";
+import { createAuthClient } from "../../client";
+import type { OAuthClient } from "../../oauth-2.1/types";
+import { oauthProviderClient } from "./client";
+import {
+	createAuthorizationCodeRequest,
+	createAuthorizationURL,
+} from "../../oauth2";
+import { generateRandomString } from "../../crypto";
+import type { MakeRequired } from "../../types/helper";
+
+describe("oauth introspect", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const rpBaseUrl = "http://localhost:5000";
+	const validAudience = "https://myapi.example.com";
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			jwt({
+				jwt: {
+					audience: validAudience,
+					issuer: authServerBaseUrl,
+				},
+			}),
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+		],
+	});
+
+	const { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: {
+			customFetchImpl,
+			headers,
+		},
+	});
+
+	let oauthClient: OAuthClient | null;
+
+	const providerId = "test";
+	const redirectUri = `${rpBaseUrl}/api/auth/oauth2/callback/${providerId}`;
+	const state = "123";
+
+	async function createAuthUrl(
+		overrides?: Partial<Parameters<typeof createAuthorizationURL>[0]>,
+	) {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+		const codeVerifier = generateRandomString(32);
+		const url = await createAuthorizationURL({
+			id: providerId,
+			options: {
+				clientId: oauthClient?.client_id,
+				clientSecret: oauthClient?.client_secret,
+				redirectURI: redirectUri,
+			},
+			redirectURI: "",
+			authorizationEndpoint: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
+			state,
+			scopes: ["openid", "profile", "email", "offline_access"],
+			codeVerifier,
+			...overrides,
+		});
+		return {
+			url,
+			codeVerifier,
+		};
+	}
+
+	async function validateAuthCode(
+		overrides: MakeRequired<
+			Partial<Parameters<typeof createAuthorizationCodeRequest>[0]>,
+			"code"
+		>,
+	) {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const { body, headers } = createAuthorizationCodeRequest({
+			...overrides,
+			redirectURI: redirectUri,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+		});
+
+		const tokens = await client.$fetch<{
+			access_token?: string;
+			id_token?: string;
+			refresh_token?: string;
+			expires_in?: number;
+			expires_at?: number;
+			token_type?: string;
+			scope?: string;
+			[key: string]: unknown;
+		}>("/oauth2/token", {
+			method: "POST",
+			body: body,
+			headers: headers,
+		});
+
+		return tokens;
+	}
+
+	async function getTokens(
+		overrides?: Partial<Parameters<typeof createAuthUrl>[0]>,
+		resource?: string,
+		authorizeHeaders?: Headers,
+	) {
+		const { url: authUrl, codeVerifier } = await createAuthUrl(overrides);
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			headers: authorizeHeaders ?? headers,
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		const url = new URL(callbackRedirectUrl);
+		return await validateAuthCode({
+			code: url.searchParams.get("code")!,
+			codeVerifier,
+			resource,
+		});
+	}
+
+	// Registers a confidential client application to work with
+	beforeAll(async () => {
+		const response = await auth.api.registerOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [redirectUri],
+				skip_consent: true,
+			},
+		});
+		expect(response?.client_id).toBeDefined();
+		expect(response?.user_id).toBeDefined();
+		expect(response?.client_secret).toBeDefined();
+		expect(response?.redirect_uris).toEqual([redirectUri]);
+		oauthClient = response;
+	});
+
+	it("should fail unauthenticated request - no client_id or client_secret", async () => {
+		const tokens = await getTokens();
+		const introspection = await client.oauth2.introspect({
+			token: tokens.data?.access_token!,
+		});
+		expect(introspection.error?.status).toBe(401);
+	});
+
+	it("should pass with token_type_hint access_token and sent jwt access_token", async () => {
+		const tokens = await getTokens(undefined, validAudience);
+		const introspection = await client.oauth2.introspect({
+			client_id: oauthClient?.client_id,
+			client_secret: oauthClient?.client_secret,
+			token: tokens.data?.access_token!,
+			token_type_hint: "access_token",
+		});
+		expect(introspection.data).toMatchObject({
+			active: true,
+			client_id: oauthClient?.client_id,
+			scope: "openid profile email offline_access",
+			sub: expect.any(String),
+			iss: authServerBaseUrl,
+			exp: expect.any(Number),
+			iat: expect.any(Number),
+			sid: expect.any(String),
+		});
+		expect(introspection.data?.aud).toContain(validAudience);
+	});
+
+	it("should pass with token_type_hint access_token and sent opaque access_token", async () => {
+		const tokens = await getTokens();
+		const introspection = await client.oauth2.introspect({
+			client_id: oauthClient?.client_id,
+			client_secret: oauthClient?.client_secret,
+			token: tokens.data?.access_token!,
+			token_type_hint: "access_token",
+		});
+		expect(introspection.data).toMatchObject({
+			active: true,
+			client_id: oauthClient?.client_id,
+			scope: "openid profile email offline_access",
+			sub: expect.any(String),
+			iss: authServerBaseUrl,
+			exp: expect.any(Number),
+			iat: expect.any(Number),
+			sid: expect.any(String),
+		});
+	});
+
+	it("should fail with token_type_hint access_token and sent refresh_token", async () => {
+		const tokens = await getTokens();
+		const introspection = await client.oauth2.introspect({
+			client_id: oauthClient?.client_id,
+			client_secret: oauthClient?.client_secret,
+			token: tokens.data?.refresh_token!,
+			token_type_hint: "access_token",
+		});
+		expect(introspection.data?.active).toBeFalsy();
+	});
+
+	it("should pass with token_type_hint refresh_token and sent refresh_token", async () => {
+		const tokens = await getTokens();
+		const introspection = await client.oauth2.introspect({
+			client_id: oauthClient?.client_id,
+			client_secret: oauthClient?.client_secret,
+			token: tokens.data?.refresh_token!,
+			token_type_hint: "refresh_token",
+		});
+		expect(introspection.data).toMatchObject({
+			active: true,
+			client_id: oauthClient?.client_id,
+			scope: "openid profile email offline_access",
+			sub: expect.any(String),
+			iss: authServerBaseUrl,
+			exp: expect.any(Number),
+			iat: expect.any(Number),
+			sid: expect.any(String),
+		});
+	});
+
+	it("should fail with token_type_hint refresh_token and sent access_token", async () => {
+		const tokens = await getTokens();
+		const introspection = await client.oauth2.introspect({
+			client_id: oauthClient?.client_id,
+			client_secret: oauthClient?.client_secret,
+			token: tokens.data?.access_token!,
+			token_type_hint: "refresh_token",
+		});
+		expect(introspection.data?.active).toBeFalsy();
+	});
+
+	it("should pass without token_type_hint and sent jwt access_token", async () => {
+		const tokens = await getTokens(undefined, validAudience);
+		const introspection = await client.oauth2.introspect({
+			client_id: oauthClient?.client_id,
+			client_secret: oauthClient?.client_secret,
+			token: tokens.data?.access_token!,
+		});
+		expect(introspection.data).toMatchObject({
+			active: true,
+			client_id: oauthClient?.client_id,
+			scope: "openid profile email offline_access",
+			sub: expect.any(String),
+			iss: authServerBaseUrl,
+			exp: expect.any(Number),
+			iat: expect.any(Number),
+			sid: expect.any(String),
+		});
+	});
+
+	it("should pass without token_type_hint and sent opaque access_token", async () => {
+		const tokens = await getTokens();
+		const introspection = await client.oauth2.introspect({
+			client_id: oauthClient?.client_id,
+			client_secret: oauthClient?.client_secret,
+			token: tokens.data?.access_token!,
+		});
+		expect(introspection.data).toMatchObject({
+			active: true,
+			client_id: oauthClient?.client_id,
+			scope: "openid profile email offline_access",
+			sub: expect.any(String),
+			iss: authServerBaseUrl,
+			exp: expect.any(Number),
+			iat: expect.any(Number),
+			sid: expect.any(String),
+		});
+	});
+
+	it("should pass without token_type_hint and sent refresh_token", async () => {
+		const tokens = await getTokens();
+		const introspection = await client.oauth2.introspect({
+			client_id: oauthClient?.client_id,
+			client_secret: oauthClient?.client_secret,
+			token: tokens.data?.refresh_token!,
+		});
+		expect(introspection.data).toMatchObject({
+			active: true,
+			client_id: oauthClient?.client_id,
+			scope: "openid profile email offline_access",
+			sub: expect.any(String),
+			iss: authServerBaseUrl,
+			exp: expect.any(Number),
+			iat: expect.any(Number),
+			sid: expect.any(String),
+		});
+	});
+
+	it("should pass opaque access_token introspection with logged out user", async () => {
+		const { headers: testHeaders } = await signInWithTestUser();
+		const tokens = await getTokens(undefined, undefined, testHeaders);
+		const signOut = await auth.api.signOut({
+			headers: testHeaders,
+		});
+		expect(signOut.success).toBe(true);
+
+		const introspection = await client.oauth2.introspect({
+			client_id: oauthClient?.client_id,
+			client_secret: oauthClient?.client_secret,
+			token: tokens.data?.access_token!,
+			token_type_hint: "access_token",
+		});
+		expect(introspection.data).toMatchObject({
+			active: true,
+			client_id: oauthClient?.client_id,
+			scope: "openid profile email offline_access",
+			sub: expect.any(String),
+			iss: authServerBaseUrl,
+			exp: expect.any(Number),
+			iat: expect.any(Number),
+		});
+		expect(introspection.data?.sid).toBeUndefined();
+	});
+
+	it("should pass jwt access_token introspection with logged out user", async () => {
+		const { headers: testHeaders } = await signInWithTestUser();
+		const tokens = await getTokens(undefined, validAudience, testHeaders);
+		const signOut = await auth.api.signOut({
+			headers: testHeaders,
+		});
+		expect(signOut.success).toBe(true);
+
+		const introspection = await client.oauth2.introspect({
+			client_id: oauthClient?.client_id,
+			client_secret: oauthClient?.client_secret,
+			token: tokens.data?.access_token!,
+			token_type_hint: "access_token",
+		});
+		expect(introspection.data).toMatchObject({
+			active: true,
+			client_id: oauthClient?.client_id,
+			scope: "openid profile email offline_access",
+			sub: expect.any(String),
+			iss: authServerBaseUrl,
+			exp: expect.any(Number),
+			iat: expect.any(Number),
+		});
+		expect(introspection.data?.aud).toContain(validAudience);
+		expect(introspection.data?.sid).toBeUndefined();
+	});
+
+	it("should pass refresh_token introspection with logged out user", async () => {
+		const { headers: testHeaders } = await signInWithTestUser();
+		const tokens = await getTokens(undefined, undefined, testHeaders);
+		const signOut = await auth.api.signOut({
+			headers: testHeaders,
+		});
+		expect(signOut.success).toBe(true);
+
+		const introspection = await client.oauth2.introspect({
+			client_id: oauthClient?.client_id,
+			client_secret: oauthClient?.client_secret,
+			token: tokens.data?.refresh_token!,
+			token_type_hint: "refresh_token",
+		});
+		expect(introspection.data).toMatchObject({
+			active: true,
+			client_id: oauthClient?.client_id,
+			scope: "openid profile email offline_access",
+			sub: expect.any(String),
+			iss: authServerBaseUrl,
+			exp: expect.any(Number),
+			iat: expect.any(Number),
+		});
+		expect(introspection.data?.sid).toBeUndefined();
+	});
+});
+
+describe("oauth introspect - config", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const rpBaseUrl = "http://localhost:5000";
+	const validAudience = "https://myapi.example.com";
+	const providerId = "test";
+	const redirectUri = `${rpBaseUrl}/api/auth/oauth2/callback/${providerId}`;
+	const scopes = [
+		"openid",
+		"email",
+		"profile",
+		"offline_access",
+		"read:profile",
+	];
+
+	async function createTestInstance(opts?: {
+		oauthProviderConfig?: Omit<OAuthOptions, "loginPage" | "consentPage">;
+	}) {
+		const { auth, customFetchImpl, signInWithTestUser } = await getTestInstance(
+			{
+				baseURL: authServerBaseUrl,
+				plugins: [
+					oauthProvider({
+						loginPage: "/login",
+						consentPage: "/consent",
+						scopes,
+						silenceWarnings: {
+							oauthAuthServerConfig: true,
+							openidConfig: true,
+						},
+						...opts?.oauthProviderConfig,
+					}),
+					...(opts?.oauthProviderConfig?.disableJwtPlugin
+						? []
+						: [
+								jwt({
+									jwt: {
+										audience: validAudience,
+										issuer: authServerBaseUrl,
+									},
+								}),
+							]),
+				],
+			},
+		);
+		const { headers } = await signInWithTestUser();
+		const client = createAuthClient({
+			plugins: [oauthProviderClient()],
+			baseURL: authServerBaseUrl,
+			fetchOptions: {
+				customFetchImpl,
+				headers,
+			},
+		});
+
+		const registeredClient = await auth.api.registerOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [redirectUri],
+				skip_consent: true,
+			},
+		});
+
+		return {
+			client,
+			oauthClient: registeredClient,
+		};
+	}
+
+	async function createAuthUrl(
+		oauthClient: OAuthClient,
+		overrides?: Partial<Parameters<typeof createAuthorizationURL>[0]>,
+	) {
+		const codeVerifier = generateRandomString(32);
+		const url = await createAuthorizationURL({
+			id: providerId,
+			options: {
+				clientId: oauthClient?.client_id,
+				clientSecret: oauthClient?.client_secret,
+				redirectURI: redirectUri,
+			},
+			redirectURI: "",
+			authorizationEndpoint: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
+			state: "123",
+			scopes: ["openid", "profile", "email", "offline_access"],
+			codeVerifier,
+			...overrides,
+		});
+		return {
+			url,
+			codeVerifier,
+		};
+	}
+
+	it("should pass with the correct opaqueAccessTokenPrefix", async () => {
+		const prefix = "hello_";
+		const testScopes = ["read:profile"];
+		const { client, oauthClient } = await createTestInstance({
+			oauthProviderConfig: {
+				opaqueAccessTokenPrefix: prefix,
+				scopes: testScopes,
+			},
+		});
+		const tokens = await client.oauth2.token({
+			grant_type: "client_credentials",
+			client_id: oauthClient?.client_id,
+			client_secret: oauthClient?.client_secret,
+			scope: testScopes.join(" "),
+			redirect_uri: redirectUri,
+		});
+		expect(tokens.data?.access_token?.startsWith(prefix)).toBeTruthy();
+
+		const introspection = await client.oauth2.introspect({
+			client_id: oauthClient?.client_id,
+			client_secret: oauthClient?.client_secret,
+			token: tokens.data?.access_token ?? "",
+			token_type_hint: "access_token",
+		});
+		expect(introspection.data).toMatchObject({
+			active: true,
+			client_id: oauthClient?.client_id,
+			scope: testScopes.join(" "),
+			iss: authServerBaseUrl,
+			exp: expect.any(Number),
+			iat: expect.any(Number),
+		});
+	});
+
+	it("should pass with the correct refreshTokenPrefix", async () => {
+		const refreshTokenPrefix = "hello_rt_";
+		const testScopes = ["openid", "offline_access"];
+		const { client, oauthClient } = await createTestInstance({
+			oauthProviderConfig: {
+				refreshTokenPrefix: refreshTokenPrefix,
+				scopes: testScopes,
+			},
+		});
+		if (!oauthClient) expect.unreachable();
+
+		const { url: authUrl, codeVerifier } = await createAuthUrl(oauthClient, {
+			scopes: testScopes,
+		});
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		const url = new URL(callbackRedirectUrl);
+		const tokens = await client.oauth2.token({
+			grant_type: "authorization_code",
+			code: url.searchParams.get("code") ?? undefined,
+			code_verifier: codeVerifier,
+			client_id: oauthClient?.client_id,
+			client_secret: oauthClient?.client_secret,
+			scope: testScopes.join(" "),
+			redirect_uri: redirectUri,
+		});
+		if ("refresh_token" in (tokens.data ?? {})) {
+			expect(
+				(tokens.data as { refresh_token?: string }).refresh_token?.startsWith(
+					refreshTokenPrefix,
+				),
+			).toBeTruthy();
+		} else {
+			expect.unreachable();
+		}
+
+		const introspection = await client.oauth2.introspect({
+			client_id: oauthClient?.client_id,
+			client_secret: oauthClient?.client_secret,
+			// @ts-expect-error refresh token sent
+			token: tokens.data?.refresh_token,
+			token_type_hint: "refresh_token",
+		});
+		expect(introspection.data).toMatchObject({
+			active: true,
+			client_id: oauthClient?.client_id,
+			scope: testScopes.join(" "),
+			iss: authServerBaseUrl,
+			sub: expect.any(String),
+			exp: expect.any(Number),
+			iat: expect.any(Number),
+		});
+	});
+});

--- a/packages/better-auth/src/plugins/oauth-provider/introspect.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/introspect.ts
@@ -1,0 +1,476 @@
+import { APIError } from "better-call";
+import type { JSONWebKeySet, JWTPayload } from "jose";
+import type { GenericEndpointContext } from "@better-auth/core";
+import type { Session, User } from "../../types";
+import {
+	basicToClientCredentials,
+	getClient,
+	getStoredToken,
+	validateClientCredentials,
+} from "./utils";
+import type {
+	OAuthOpaqueAccessToken,
+	OAuthOptions,
+	OAuthRefreshToken,
+} from "./types";
+import { getJwtPlugin } from "./utils";
+import { decodeRefreshToken } from "./token";
+import { verifyJwsAccessToken } from "./verify";
+import { logger } from "@better-auth/core/env";
+
+/**
+ * IMPORTANT NOTES:
+ * Instropection follows RFC7662
+ * https://datatracker.ietf.org/doc/html/rfc7662
+ * - APIError: Continue catches (returnable to client)
+ * - Error: Should immediately stop catches (internal error)
+ */
+
+/**
+ * Validates a JWT access token against the configured JWKs.
+ *
+ * @returns RFC7662 introspection format
+ */
+async function validateJwtAccessToken(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions,
+	token: string,
+	clientId?: string,
+) {
+	const jwtPlugin = opts.disableJwtPlugin
+		? undefined
+		: getJwtPlugin(ctx.context);
+	const jwtPluginOptions = jwtPlugin?.options;
+	let jwtPayload: JWTPayload & {
+		sid?: string;
+		azp?: string;
+	};
+
+	try {
+		jwtPayload = await verifyJwsAccessToken(token, {
+			jwksFetch: jwtPluginOptions?.jwks?.remoteUrl
+				? jwtPluginOptions.jwks.remoteUrl
+				: async () => {
+						const jwksRes = await jwtPlugin?.endpoints.getJwks(ctx);
+						// @ts-expect-error response is a JSONWebKeySet but within the response field
+						return jwksRes?.response as JSONWebKeySet | undefined;
+					},
+			verifyOptions: {
+				audience: jwtPluginOptions?.jwt?.audience ?? ctx.context.baseURL,
+				issuer: jwtPluginOptions?.jwt?.issuer ?? ctx.context.baseURL,
+			},
+		});
+	} catch (error) {
+		if (error instanceof Error) {
+			if (error.name === "TypeError" || error.name === "JWSInvalid") {
+				// likely an opaque token
+				throw new APIError("BAD_REQUEST", {
+					error_description: "invalid JWT signature",
+					error: "invalid_request",
+				});
+			} else if (error.name === "JWTExpired") {
+				return {
+					active: false,
+				};
+			} else if (error.name === "JWTInvalid") {
+				// audience or issuer mismatch
+				return {
+					active: false,
+				};
+			}
+			throw error;
+		}
+		throw new Error(error as unknown as string);
+	}
+
+	if (jwtPayload.azp) {
+		if (clientId && jwtPayload.azp !== clientId) {
+			return {
+				active: false,
+			};
+		} else if (!clientId) {
+			const client = await getClient(ctx, opts, jwtPayload.azp);
+			if (!client || client?.disabled) {
+				return {
+					active: false,
+				};
+			}
+		}
+	}
+
+	// Validate JWT against its session if it exists
+	let sessionId = jwtPayload.sid;
+	if (sessionId) {
+		const session = await ctx.context.adapter.findOne<Session>({
+			model: "session",
+			where: [
+				{
+					field: "id",
+					value: sessionId,
+				},
+			],
+		});
+		if (!session || session.expiresAt < new Date()) {
+			jwtPayload.sid = undefined;
+		}
+	}
+
+	// Return the JWT payload in introspection format
+	// https://datatracker.ietf.org/doc/html/rfc7662#section-2.2
+	if (jwtPayload.azp) {
+		jwtPayload.client_id = jwtPayload.azp;
+	}
+	jwtPayload.active = true;
+	return jwtPayload;
+}
+
+/**
+ * Searches for an opaque access token in the database and validates it
+ *
+ * @returns RFC7662 introspection format
+ */
+async function validateOpaqueAccessToken(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions,
+	token: string,
+	clientId?: string,
+) {
+	let tokenValue = token;
+	if (opts.opaqueAccessTokenPrefix) {
+		if (tokenValue.startsWith(opts.opaqueAccessTokenPrefix)) {
+			tokenValue = tokenValue.replace(opts.opaqueAccessTokenPrefix, "");
+		} else {
+			throw new APIError("BAD_REQUEST", {
+				error_description: "opaque access token not found",
+				error: "invalid_request",
+			});
+		}
+	}
+	const accessToken = await ctx.context.adapter
+		.findOne<OAuthOpaqueAccessToken>({
+			model: opts.schema?.oauthAccessToken?.modelName ?? "oauthAccessToken",
+			where: [
+				{
+					field: "token",
+					value: await getStoredToken(
+						opts.storeTokens,
+						tokenValue,
+						"access_token",
+					),
+				},
+			],
+		})
+		.then((res) => {
+			// TODO: remove join when native arrays supported
+			if (!res) return res;
+			return {
+				...res,
+				scopes: (res.scopes as unknown as string)?.split(" "),
+			} as OAuthOpaqueAccessToken;
+		});
+	if (!accessToken) {
+		// Pass through, may be other token type
+		throw new APIError("BAD_REQUEST", {
+			error_description: "opaque access token not found",
+			error: "invalid_token",
+		});
+	}
+	if (clientId && accessToken.clientId !== clientId) {
+		return {
+			active: false,
+		};
+	}
+	if (!accessToken.expiresAt || accessToken.expiresAt < new Date()) {
+		return {
+			active: false,
+		};
+	}
+
+	let sessionId = accessToken.sessionId ?? undefined;
+	if (sessionId) {
+		const session = await ctx.context.adapter.findOne<Session>({
+			model: "session",
+			where: [
+				{
+					field: "id",
+					value: sessionId,
+				},
+			],
+		});
+		if (!session || session.expiresAt < new Date()) {
+			sessionId = undefined;
+		}
+	}
+
+	let user: User | undefined;
+	if (accessToken.userId) {
+		user =
+			(await ctx.context.internalAdapter.findUserById(accessToken?.userId)) ??
+			undefined;
+	}
+
+	// Return the access token in introspection format
+	// https://datatracker.ietf.org/doc/html/rfc7662#section-2.2
+	const jwtPlugin = opts.disableJwtPlugin
+		? undefined
+		: getJwtPlugin(ctx.context);
+	const jwtPluginOptions = jwtPlugin?.options;
+	return {
+		active: true,
+		iss: jwtPluginOptions?.jwt?.issuer ?? ctx.context.baseURL,
+		client_id: accessToken.clientId,
+		sub: user?.id,
+		sid: sessionId,
+		exp: Math.floor(accessToken.expiresAt.getTime() / 1000),
+		iat: Math.floor(accessToken.createdAt.getTime() / 1000),
+		scope: accessToken.scopes?.join(" "),
+	} as JWTPayload;
+}
+
+/**
+ * Validates a refresh token in the session store.
+ *
+ * @returns payload in RFC7662 introspection format
+ */
+async function validateRefreshToken(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions,
+	token: string,
+	clientId: string,
+) {
+	const refreshToken = await ctx.context.adapter
+		.findOne<OAuthRefreshToken | null>({
+			model: "oauthRefreshToken",
+			where: [
+				{
+					field: "token",
+					value: await getStoredToken(opts.storeTokens, token, "refresh_token"),
+				},
+			],
+		})
+		.then((res) => {
+			// TODO: remove join when native arrays supported
+			if (!res) return res;
+			return {
+				...res,
+				scopes: (res.scopes as unknown as string)?.split(" "),
+			};
+		});
+	if (!refreshToken) {
+		// Pass through may be other token type
+		throw new APIError("BAD_REQUEST", {
+			error_description: "token not found",
+			error: "invalid_token",
+		});
+	}
+	if (!refreshToken.clientId || refreshToken.clientId !== clientId) {
+		return {
+			active: false,
+		};
+	}
+	if (!refreshToken.expiresAt || refreshToken.expiresAt < new Date()) {
+		return {
+			active: false,
+		};
+	}
+
+	let sessionId: string | undefined = refreshToken.sessionId ?? undefined;
+	if (sessionId) {
+		const session = await ctx.context.adapter.findOne<Session>({
+			model: "session",
+			where: [
+				{
+					field: "id",
+					value: refreshToken.sessionId,
+				},
+			],
+		});
+		if (!session || session.expiresAt < new Date()) {
+			sessionId = undefined;
+		}
+	}
+
+	let user: User | undefined = undefined;
+	if (refreshToken.userId) {
+		user =
+			(await ctx.context.internalAdapter.findUserById(refreshToken?.userId)) ??
+			undefined;
+	}
+
+	// Return the access token in introspection format
+	// https://datatracker.ietf.org/doc/html/rfc7662#section-2.2
+	const jwtPlugin = opts.disableJwtPlugin
+		? undefined
+		: getJwtPlugin(ctx.context);
+	const jwtPluginOptions = jwtPlugin?.options;
+
+	return {
+		active: true,
+		client_id: clientId,
+		iss: jwtPluginOptions?.jwt?.issuer ?? ctx.context.baseURL,
+		sub: user?.id,
+		sid: sessionId,
+		exp: Math.floor(refreshToken.expiresAt.getTime() / 1000),
+		iat: Math.floor(refreshToken.createdAt.getTime() / 1000),
+		scope: refreshToken.scopes?.join(" "),
+	} as JWTPayload;
+}
+
+/**
+ * We don't know the access token format so we try to validate it
+ * as a JWT first, then as an opaque token.
+ *
+ * @returns RFC7662 introspection format
+ *
+ * @internal
+ */
+export async function validateAccessToken(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions,
+	token: string,
+	clientId?: string,
+) {
+	try {
+		return await validateJwtAccessToken(ctx, opts, token, clientId);
+	} catch (err) {
+		if (err instanceof APIError) {
+			// continue
+		} else if (err instanceof Error) {
+			throw err;
+		} else {
+			throw new Error(err as unknown as string);
+		}
+	}
+	try {
+		return await validateOpaqueAccessToken(ctx, opts, token, clientId);
+	} catch (err) {
+		if (err instanceof APIError) {
+			// nothing
+		} else if (err instanceof Error) {
+			throw err;
+		} else {
+			throw new Error("Unknown error validating access token");
+		}
+	}
+	throw new APIError("BAD_REQUEST", {
+		error_description: "Invalid access token",
+		error: "invalid_request",
+	});
+}
+
+export async function introspectEndpoint(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions,
+) {
+	let {
+		client_id,
+		client_secret,
+		token,
+		token_type_hint,
+	}: {
+		client_id?: string;
+		client_secret?: string;
+		token: string;
+		token_type_hint?: "access_token" | "refresh_token";
+	} = ctx.body;
+
+	// Convert basic authorization
+	const authorization = ctx.request?.headers.get("authorization") || null;
+	if (authorization?.startsWith("Basic ")) {
+		const res = basicToClientCredentials(authorization);
+		client_id = res?.client_id;
+		client_secret = res?.client_secret;
+	}
+	if (!client_id || !client_secret) {
+		throw new APIError("UNAUTHORIZED", {
+			error_description: "missing required credentials",
+			error: "invalid_client",
+		});
+	}
+
+	// Check token
+	if (token && typeof token === "string" && token.startsWith("Bearer ")) {
+		token = token.replace("Bearer ", "");
+	}
+	if (!token?.length) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "missing a required token for introspection",
+			error: "invalid_request",
+		});
+	}
+
+	// Validate client credentials
+	const client = await validateClientCredentials(
+		ctx,
+		opts,
+		client_id,
+		client_secret,
+	);
+
+	try {
+		if (token_type_hint === undefined || token_type_hint === "access_token") {
+			try {
+				const payload = await validateAccessToken(
+					ctx,
+					opts,
+					token,
+					client.clientId,
+				);
+				return ctx.json(payload);
+			} catch (error) {
+				if (error instanceof APIError) {
+					if (token_type_hint === "access_token") {
+						throw error;
+					} // else continue
+				} else if (error instanceof Error) {
+					throw error;
+				} else {
+					throw new Error(error as unknown as string);
+				}
+			}
+		}
+
+		if (token_type_hint === undefined || token_type_hint === "refresh_token") {
+			try {
+				const refreshToken = await decodeRefreshToken(opts, token);
+				const payload = await validateRefreshToken(
+					ctx,
+					opts,
+					refreshToken.token,
+					client.clientId,
+				);
+				return ctx.json(payload);
+			} catch (error) {
+				if (error instanceof APIError) {
+					if (token_type_hint === "refresh_token") {
+						throw error;
+					} // else continue
+				} else if (error instanceof Error) {
+					throw error;
+				} else {
+					throw new Error(error as unknown as string);
+				}
+			}
+		}
+
+		throw new APIError("BAD_REQUEST", {
+			error_description: "token not found",
+			error: "invalid_request",
+		});
+	} catch (error) {
+		if (error instanceof APIError) {
+			if (error.name === "BAD_REQUEST") {
+				return {
+					active: false,
+				};
+			}
+			throw error;
+		} else if (error instanceof Error) {
+			logger.error("Introspection error:", error.message, error.stack);
+			throw new APIError("INTERNAL_SERVER_ERROR");
+		} else {
+			logger.error("Introspection error:", error);
+			throw new APIError("INTERNAL_SERVER_ERROR");
+		}
+	}
+}

--- a/packages/better-auth/src/plugins/oauth-provider/mcp.test.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/mcp.test.ts
@@ -31,7 +31,7 @@ describe("mcp", async () => {
 	let oauthClient: OAuthClient | null;
 
 	beforeAll(async () => {
-		const response = await auth.api.registerOAuthClient({
+		const response = await auth.api.createOAuthClient({
 			headers,
 			body: {
 				redirect_uris: [redirectUri],

--- a/packages/better-auth/src/plugins/oauth-provider/mcp.test.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/mcp.test.ts
@@ -1,88 +1,63 @@
-import { beforeAll, describe, it, expect } from "vitest";
-import { getTestInstance } from "../../test-utils/test-instance";
-import { oauthProvider } from "./oauth";
-import { jwt } from "../jwt";
-import type { OAuthClient } from "../../oauth-2.1/types";
+import { describe, it, expect } from "vitest";
 import { mcpHandler } from "./mcp";
+import { createAuthClient } from "../../client";
+import { oauthProviderClient } from "./client";
+import type { APIError } from "better-call";
 
 describe("mcp", async () => {
 	const authServerUrl = `http://localhost:3000`;
 	const apiServerBaseUrl = "http://localhost:5000";
-	const providerId = "test";
-	const redirectUri = `${apiServerBaseUrl}/api/auth/oauth2/callback/${providerId}`;
 
-	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
-		baseURL: authServerUrl,
-		plugins: [
-			jwt(),
-			oauthProvider({
-				loginPage: "/login",
-				consentPage: "/consent",
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
-			}),
-		],
-	});
-
-	const { headers } = await signInWithTestUser();
-
-	let oauthClient: OAuthClient | null;
-
-	beforeAll(async () => {
-		const response = await auth.api.createOAuthClient({
-			headers,
-			body: {
-				redirect_uris: [redirectUri],
-				skip_consent: true,
-			},
-		});
-		expect(response?.client_id).toBeDefined();
-		expect(response?.user_id).toBeDefined();
-		expect(response?.client_secret).toBeDefined();
-		expect(response?.redirect_uris).toEqual([redirectUri]);
-		oauthClient = response;
-	});
-
-	it("should return 401 if the request is not authenticated returning the right WWW-Authenticate header", async ({
-		expect,
-	}) => {
-		// @ts-expect-error
-		const response = await mcpHandler(auth, authServerUrl, async () => {
-			return new Response("unused");
-		})(new Request(`${authServerUrl}/mcp`));
-
-		expect(response.status).toBe(401);
-		expect(response.headers.get("WWW-Authenticate")).toBe(
-			`Bearer resource_metadata="${authServerUrl}/.well-known/oauth-protected-resource"`,
-		);
+	const apiClient = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: apiServerBaseUrl,
 	});
 
 	it.each([
 		{
-			resource: "https://api.example.com",
-			correctPath: "",
+			resource: apiServerBaseUrl,
+			expected: `Bearer resource_metadata="${apiServerBaseUrl}/.well-known/oauth-protected-resource"`,
 		},
 		{
-			resource: "https://api.example.com/resource1",
-			correctPath: "/resource1",
+			resource: `${apiServerBaseUrl}/resource1`,
+			expected: `Bearer resource_metadata="${apiServerBaseUrl}/.well-known/oauth-protected-resource/resource1"`,
 		},
 		{
-			resource: "https://api.example.com/resource1?version=2",
-			correctPath: "/resource1?version=2",
+			resource: [apiServerBaseUrl, `${apiServerBaseUrl}/resource1`],
+			expected: `Bearer resource_metadata="${apiServerBaseUrl}/.well-known/oauth-protected-resource", Bearer resource_metadata="${apiServerBaseUrl}/.well-known/oauth-protected-resource/resource1"`,
 		},
-	] as const)(
+	])(
 		"should provide the correct metadata using resource: $resource",
-		async ({ resource, correctPath }) => {
-			// @ts-expect-error
-			const response = await mcpHandler(auth, resource, async () => {
-				return new Response("unused");
-			})(new Request(`${authServerUrl}/mcp`));
-			expect(response.status).toBe(401);
-			expect(response.headers.get("WWW-Authenticate")).toBe(
-				`Bearer resource_metadata="https://api.example.com/.well-known/oauth-protected-resource${correctPath}"`,
-			);
+		async ({ resource, expected }) => {
+			try {
+				await apiClient.verifyAccessToken("bad_access_token", {
+					verifyOptions: {
+						issuer: authServerUrl,
+						audience: resource,
+					},
+				});
+				expect.unreachable();
+			} catch (error) {
+				const err = error as APIError;
+				expect(err?.statusCode).toBe(401);
+				expect(new Headers(err.headers)?.get("WWW-Authenticate")).toBe(
+					expected,
+				);
+			}
+
+			const response = await mcpHandler(
+				{
+					verifyOptions: {
+						issuer: authServerUrl,
+						audience: resource,
+					},
+				},
+				async () => {
+					return new Response("unused");
+				},
+			)(new Request(`${authServerUrl}/mcp`));
+			expect(response?.status).toBe(401);
+			expect(response?.headers.get("WWW-Authenticate")).toBe(expected);
 		},
 	);
 });

--- a/packages/better-auth/src/plugins/oauth-provider/mcp.test.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/mcp.test.ts
@@ -1,0 +1,88 @@
+import { beforeAll, describe, it, expect } from "vitest";
+import { getTestInstance } from "../../test-utils/test-instance";
+import { oauthProvider } from "./oauth";
+import { jwt } from "../jwt";
+import type { OAuthClient } from "../../oauth-2.1/types";
+import { mcpHandler } from "./mcp";
+
+describe("mcp", async () => {
+	const authServerUrl = `http://localhost:3000`;
+	const apiServerBaseUrl = "http://localhost:5000";
+	const providerId = "test";
+	const redirectUri = `${apiServerBaseUrl}/api/auth/oauth2/callback/${providerId}`;
+
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL: authServerUrl,
+		plugins: [
+			jwt(),
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+		],
+	});
+
+	const { headers } = await signInWithTestUser();
+
+	let oauthClient: OAuthClient | null;
+
+	beforeAll(async () => {
+		const response = await auth.api.registerOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [redirectUri],
+				skip_consent: true,
+			},
+		});
+		expect(response?.client_id).toBeDefined();
+		expect(response?.user_id).toBeDefined();
+		expect(response?.client_secret).toBeDefined();
+		expect(response?.redirect_uris).toEqual([redirectUri]);
+		oauthClient = response;
+	});
+
+	it("should return 401 if the request is not authenticated returning the right WWW-Authenticate header", async ({
+		expect,
+	}) => {
+		// @ts-expect-error
+		const response = await mcpHandler(auth, authServerUrl, async () => {
+			return new Response("unused");
+		})(new Request(`${authServerUrl}/mcp`));
+
+		expect(response.status).toBe(401);
+		expect(response.headers.get("WWW-Authenticate")).toBe(
+			`Bearer resource_metadata="${authServerUrl}/.well-known/oauth-protected-resource"`,
+		);
+	});
+
+	it.each([
+		{
+			resource: "https://api.example.com",
+			correctPath: "",
+		},
+		{
+			resource: "https://api.example.com/resource1",
+			correctPath: "/resource1",
+		},
+		{
+			resource: "https://api.example.com/resource1?version=2",
+			correctPath: "/resource1?version=2",
+		},
+	] as const)(
+		"should provide the correct metadata using resource: $resource",
+		async ({ resource, correctPath }) => {
+			// @ts-expect-error
+			const response = await mcpHandler(auth, resource, async () => {
+				return new Response("unused");
+			})(new Request(`${authServerUrl}/mcp`));
+			expect(response.status).toBe(401);
+			expect(response.headers.get("WWW-Authenticate")).toBe(
+				`Bearer resource_metadata="https://api.example.com/.well-known/oauth-protected-resource${correctPath}"`,
+			);
+		},
+	);
+});

--- a/packages/better-auth/src/plugins/oauth-provider/mcp.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/mcp.ts
@@ -1,0 +1,99 @@
+import type { BetterAuthOptions } from "../../types";
+import type { Awaitable } from "../../types/helper";
+import { type JWTPayload } from "jose";
+import { APIError } from "better-call";
+import { verifyAccessToken } from "./verify";
+import type { betterAuth } from "../../auth";
+import { logger } from "@better-auth/core/env";
+
+/**
+ * A request middleware handler that checks and responds with
+ * a WWW-Authenticate header for unauthenticated responses.
+ *
+ * Passes through authenticated tokens.
+ * Provides valid Jwt payloads on `req.context.jwt`.
+ *
+ * @external
+ */
+export const mcpHandler = <
+	Auth extends typeof betterAuth & {
+		api: {
+			oauth2IntrospectVerify: (...args: any) => Promise<JWTPayload | null>;
+		};
+		baseURL: string;
+		options: BetterAuthOptions;
+	},
+	Request extends {
+		readonly url: string;
+		readonly headers: Headers;
+		context?: {
+			jwt?: JWTPayload;
+		};
+	},
+>(
+	auth: Auth,
+	/** Resource is the same url as the audience */
+	resource: string,
+	handler: (req: Request) => Awaitable<Response>,
+	opts?: Parameters<typeof verifyAccessToken>[1],
+) => {
+	return async (req: Request) => {
+		const authorization = req.headers?.get("authorization") ?? undefined;
+		const accessToken = authorization?.startsWith("Bearer ")
+			? authorization.replace("Bearer ", "")
+			: authorization;
+		try {
+			const token = await auth.api.oauth2IntrospectVerify({
+				body: {
+					token: accessToken,
+					verifyOpts: opts,
+				},
+			});
+			if (!req.context) req.context = {};
+			req.context.jwt = token ?? undefined;
+		} catch (error) {
+			try {
+				return handleMcpErrors(error, resource);
+			} catch (err) {
+				logger.error(err as unknown as string);
+				if (err instanceof Error) throw err;
+				throw new Error(String(err));
+			}
+		}
+		return handler(req);
+	};
+};
+
+/**
+ * The following handles all MCP errors and API errors
+ *
+ * @external
+ */
+export function handleMcpErrors(error: unknown, resource: string | URL) {
+	if (error instanceof APIError && error.status === "UNAUTHORIZED") {
+		const _resource =
+			typeof resource === "string" ? new URL(resource) : resource;
+		let audiencePath = _resource.pathname + _resource.search;
+		if (audiencePath.endsWith("/")) audiencePath = audiencePath.slice(0, -1);
+
+		const wwwAuthenticateValue = `Bearer resource_metadata="${_resource.origin}/.well-known/oauth-protected-resource${
+			audiencePath
+		}"`;
+		return new Response(error.message, {
+			status: 401,
+			headers: {
+				"Content-Type": "application/json",
+				"WWW-Authenticate": wwwAuthenticateValue,
+			},
+		});
+	} else if (error instanceof APIError) {
+		return new Response(error.message, {
+			status: error.statusCode,
+			headers: error.headers,
+		});
+	} else if (error instanceof Error) {
+		throw error;
+	} else {
+		throw new Error(error as unknown as string);
+	}
+}

--- a/packages/better-auth/src/plugins/oauth-provider/metadata.test.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/metadata.test.ts
@@ -1,0 +1,421 @@
+import { describe, it, expect } from "vitest";
+import { getTestInstance } from "../../test-utils/test-instance";
+import { jwt, type JwtOptions } from "../jwt";
+import { oauthProvider } from "./oauth";
+import { oauthProviderProtectedResourceMetadata } from "./metadata";
+import { BetterAuthError } from "@better-auth/core/error";
+import { createAuthClient } from "../../client";
+import type { OAuthOptions } from "./types";
+import type { ResourceServerMetadata } from "../../oauth-2.1/types";
+import { oauthProviderClient } from "./client";
+import { APIError } from "better-call";
+
+describe("oauth metadata", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const baseURL = `${authServerBaseUrl}/api/auth`;
+	const baseClaims = [
+		"sub",
+		"iss",
+		"aud",
+		"exp",
+		"iat",
+		"sid",
+		"scope",
+		"azp",
+		"email",
+		"email_verified",
+		"name",
+		"picture",
+		"family_name",
+		"given_name",
+	];
+
+	async function createTestInstance(opts?: {
+		oauthProviderConfig?: Omit<OAuthOptions, "loginPage" | "consentPage">;
+		jwtConfig?: JwtOptions;
+	}) {
+		const { auth, customFetchImpl } = await getTestInstance({
+			baseURL: authServerBaseUrl,
+			plugins: [
+				oauthProvider({
+					loginPage: "/login",
+					consentPage: "/consent",
+					silenceWarnings: {
+						oauthAuthServerConfig: true,
+						openidConfig: true,
+					},
+					...opts?.oauthProviderConfig,
+				}),
+				...(opts?.oauthProviderConfig?.disableJwtPlugin
+					? []
+					: [jwt(opts?.jwtConfig)]),
+			],
+		});
+
+		const unauthenticatedClient = createAuthClient({
+			plugins: [oauthProviderClient()],
+			baseURL: authServerBaseUrl,
+			fetchOptions: {
+				customFetchImpl,
+			},
+		});
+
+		return {
+			auth,
+			client: unauthenticatedClient,
+		};
+	}
+
+	it("should get openid, equivalent auth server", async () => {
+		const { auth } = await createTestInstance();
+		const metadata = await auth.api.getOpenIdConfig();
+		expect(metadata).toMatchObject({
+			scopes_supported: ["openid", "profile", "email", "offline_access"],
+			issuer: baseURL,
+			authorization_endpoint: `${baseURL}/oauth2/authorize`,
+			token_endpoint: `${baseURL}/oauth2/token`,
+			jwks_uri: `${baseURL}/jwks`,
+			registration_endpoint: `${baseURL}/oauth2/register`,
+			introspection_endpoint: `${baseURL}/oauth2/introspect`,
+			revocation_endpoint: `${baseURL}/oauth2/revoke`,
+			response_types_supported: ["code"],
+			response_modes_supported: ["query"],
+			grant_types_supported: [
+				"authorization_code",
+				"client_credentials",
+				"refresh_token",
+			],
+			token_endpoint_auth_methods_supported: [
+				"client_secret_basic",
+				"client_secret_post",
+			],
+			introspection_endpoint_auth_methods_supported: [
+				"client_secret_basic",
+				"client_secret_post",
+			],
+			revocation_endpoint_auth_methods_supported: [
+				"client_secret_basic",
+				"client_secret_post",
+			],
+			code_challenge_methods_supported: ["S256"],
+			claims_supported: baseClaims,
+			userinfo_endpoint: `${baseURL}/oauth2/userinfo`,
+			subject_types_supported: ["public"],
+			id_token_signing_alg_values_supported: ["EdDSA"],
+			acr_values_supported: ["urn:mace:incommon:iap:bronze"],
+		});
+		const oauthMetadata = await auth.api.getOAuthServerConfig();
+		expect(oauthMetadata).toMatchObject(metadata ?? {});
+	});
+
+	it("should not have an openid-configuration, has auth server configuration", async () => {
+		const scopes = ["create:test"];
+		const { auth } = await createTestInstance({
+			oauthProviderConfig: {
+				scopes,
+			},
+		});
+		await expect(auth.api.getOpenIdConfig()).rejects.toThrowError(
+			new APIError("NOT_FOUND"),
+		);
+		const oauthMetadata = await auth.api.getOAuthServerConfig();
+		expect(oauthMetadata).toMatchObject({
+			scopes_supported: scopes,
+			issuer: baseURL,
+			authorization_endpoint: `${baseURL}/oauth2/authorize`,
+			token_endpoint: `${baseURL}/oauth2/token`,
+			jwks_uri: `${baseURL}/jwks`,
+			registration_endpoint: `${baseURL}/oauth2/register`,
+			introspection_endpoint: `${baseURL}/oauth2/introspect`,
+			revocation_endpoint: `${baseURL}/oauth2/revoke`,
+			response_types_supported: ["code"],
+			response_modes_supported: ["query"],
+			grant_types_supported: [
+				"authorization_code",
+				"client_credentials",
+				"refresh_token",
+			],
+			token_endpoint_auth_methods_supported: [
+				"client_secret_basic",
+				"client_secret_post",
+			],
+			introspection_endpoint_auth_methods_supported: [
+				"client_secret_basic",
+				"client_secret_post",
+			],
+			revocation_endpoint_auth_methods_supported: [
+				"client_secret_basic",
+				"client_secret_post",
+			],
+			code_challenge_methods_supported: ["S256"],
+		});
+	});
+
+	it("should utilize advertised metadata fields", async () => {
+		const advertisedScopes = ["email"];
+		const advertisedClaims = ["sub", "iss", "aud", "exp", "iat", "scope"];
+		const { auth } = await createTestInstance({
+			oauthProviderConfig: {
+				advertisedMetadata: {
+					scopes_supported: advertisedScopes,
+					claims_supported: advertisedClaims,
+				},
+			},
+		});
+		const metadata = await auth.api.getOpenIdConfig();
+		expect(metadata).toMatchObject({
+			scopes_supported: advertisedScopes,
+			claims_supported: advertisedClaims,
+		});
+		const oauthMetadata = await auth.api.getOAuthServerConfig();
+		expect(oauthMetadata).toMatchObject(metadata ?? {});
+	});
+
+	it("should fail if advertised scope invalid", async () => {
+		const advertisedScopes = ["create:test"];
+		expect(() =>
+			getTestInstance({
+				baseURL: authServerBaseUrl,
+				plugins: [
+					oauthProvider({
+						loginPage: "/login",
+						consentPage: "/consent",
+						advertisedMetadata: {
+							scopes_supported: advertisedScopes,
+						},
+						silenceWarnings: {
+							oauthAuthServerConfig: true,
+							openidConfig: true,
+						},
+					}),
+					jwt(),
+				],
+			}),
+		).toThrowError(
+			"advertisedMetadata.scopes_supported create:test not found in scopes",
+		);
+	});
+
+	it("should fail if advertised claim not a valid claim", async () => {
+		const advertisedClaims = ["http://example.com/roles"];
+		expect(() =>
+			getTestInstance({
+				baseURL: authServerBaseUrl,
+				plugins: [
+					oauthProvider({
+						loginPage: "/login",
+						consentPage: "/consent",
+						advertisedMetadata: {
+							claims_supported: advertisedClaims,
+						},
+					}),
+					jwt(),
+				],
+			}),
+		).toThrowError(
+			"advertisedMetadata.claims_supported http://example.com/roles not found in claims",
+		);
+	});
+
+	it("should advertise custom claims", async () => {
+		const customClaims = ["http://example.com/roles"];
+		const { auth } = await createTestInstance({
+			oauthProviderConfig: {
+				customClaims: customClaims,
+			},
+		});
+		const metadata = await auth.api.getOpenIdConfig();
+		expect(metadata).toMatchObject({
+			claims_supported: [...baseClaims, ...customClaims],
+		});
+		const oauthMetadata = await auth.api.getOAuthServerConfig();
+		expect(oauthMetadata).toMatchObject(metadata ?? {});
+	});
+
+	it("should use the remoteJwks url", async () => {
+		const remoteUrl = "http://example.com/.well-known/openid-configuration";
+		const alg = "ES256";
+		const { auth } = await createTestInstance({
+			jwtConfig: {
+				jwks: {
+					remoteUrl,
+					keyPairConfig: {
+						alg,
+					},
+				},
+			},
+		});
+		const metadata = await auth.api.getOpenIdConfig();
+		expect(metadata).toMatchObject({
+			jwks_uri: remoteUrl,
+			id_token_signing_alg_values_supported: [alg],
+		});
+		const oauthMetadata = await auth.api.getOAuthServerConfig();
+		expect(oauthMetadata).toMatchObject(metadata ?? {});
+	});
+
+	it("should support disableJwtPlugin", async () => {
+		const { auth } = await createTestInstance({
+			oauthProviderConfig: {
+				disableJwtPlugin: true,
+			},
+		});
+		const metadata = await auth.api.getOpenIdConfig();
+		expect(metadata).toMatchObject({
+			id_token_signing_alg_values_supported: ["HS256"],
+		});
+		const oauthMetadata = await auth.api.getOAuthServerConfig();
+		expect(oauthMetadata).toMatchObject(metadata ?? {});
+	});
+});
+
+describe("metadata - resource discovery functions", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const validAudience = "https://myapi.example.com";
+	const supportedScopes = [
+		"openid",
+		"profile",
+		"email",
+		"offline_access",
+		"read:posts",
+	];
+	const { auth } = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			jwt({
+				jwt: {
+					audience: validAudience,
+					issuer: authServerBaseUrl,
+				},
+			}),
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				scopes: supportedScopes,
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+		],
+	});
+
+	it("should provide resource discovery configuration", async () => {
+		const metadata = await auth.api.getOAuthProtectedResourceConfig();
+		expect(metadata).toMatchObject({
+			resource: validAudience, // aud
+			authorization_servers: [authServerBaseUrl], // iss
+		});
+	});
+
+	it("should allow overwriting any field", async () => {
+		const anotherIssuer = "https://admin.example.com";
+		const anotherResource = "https://another-api.example.com";
+		const metadata = await auth.api.getOAuthProtectedResourceConfig({
+			body: {
+				overrides: {
+					resource: anotherResource,
+					authorization_servers: [anotherIssuer],
+				},
+			},
+		});
+		expect(metadata).toMatchObject({
+			resource: anotherResource,
+			authorization_servers: [anotherIssuer],
+		});
+	});
+
+	it("oauthProviderProtectedResourceMetadata - should pass without opts providing resource discovery configuration", async () => {
+		// @ts-expect-error Full auth not provided
+		const metadataEndpoint = oauthProviderProtectedResourceMetadata(auth);
+		const metadataRes = await metadataEndpoint(
+			new Request("http://localhost/.well-known/oauth-protected-resource", {
+				method: "GET",
+			}),
+		);
+		expect(metadataRes.ok).toBeTruthy();
+		const metadata: ResourceServerMetadata = await metadataRes.json();
+		expect(metadata).toMatchObject({
+			resource: validAudience, // aud
+			authorization_servers: [authServerBaseUrl], // iss
+		});
+	});
+
+	it("oauthProviderProtectedResourceMetadata - should not support 'openid' scope", async () => {
+		try {
+			// @ts-expect-error Full auth not provided
+			oauthProviderProtectedResourceMetadata(auth, {
+				overrides: {
+					scopes_supported: ["openid"],
+				},
+			});
+			expect.unreachable();
+		} catch (error) {
+			expect(error instanceof BetterAuthError).toBeTruthy();
+		}
+	});
+
+	it("oauthProviderProtectedResourceMetadata - should pass with supported scopes", async () => {
+		// @ts-expect-error Full auth not provided
+		const metadataEndpoint = oauthProviderProtectedResourceMetadata(auth, {
+			overrides: {
+				scopes_supported: ["read:posts"],
+			},
+		});
+		const metadataRes = await metadataEndpoint(
+			new Request("http://localhost/.well-known/oauth-protected-resource", {
+				method: "GET",
+			}),
+		);
+		expect(metadataRes.ok).toBeTruthy();
+		const metadata: ResourceServerMetadata = await metadataRes.json();
+		expect(metadata).toMatchObject({
+			resource: validAudience, // aud
+			authorization_servers: [authServerBaseUrl], // iss
+			scopes_supported: ["read:posts"],
+		});
+	});
+
+	it("oauthProviderProtectedResourceMetadata - should fail unsupported scope", async () => {
+		try {
+			// @ts-expect-error Full auth not provided
+			oauthProviderProtectedResourceMetadata(auth, {
+				overrides: {
+					scopes_supported: ["write:posts"],
+				},
+			});
+			expect.unreachable();
+		} catch (error) {
+			expect(error instanceof BetterAuthError).toBeTruthy();
+		}
+	});
+
+	it("oauthProviderProtectedResourceMetadata - should pass externally available scopes", async () => {
+		// @ts-expect-error Full auth not provided
+		const metadataEndpoint = oauthProviderProtectedResourceMetadata(auth, {
+			externalScopes: ["write:posts"],
+			overrides: {
+				authorization_servers: [
+					authServerBaseUrl,
+					"https://another.example.com",
+				],
+				scopes_supported: ["read:posts", "write:posts"],
+			},
+		});
+		const metadataRes = await metadataEndpoint(
+			new Request("http://localhost/.well-known/oauth-protected-resource", {
+				method: "GET",
+			}),
+		);
+		expect(metadataRes.ok).toBeTruthy();
+		const metadata: ResourceServerMetadata = await metadataRes.json();
+		expect(metadata).toMatchObject({
+			resource: validAudience, // aud
+			authorization_servers: [
+				authServerBaseUrl, // iss
+				"https://another.example.com",
+			],
+			scopes_supported: ["read:posts", "write:posts"],
+		});
+	});
+});

--- a/packages/better-auth/src/plugins/oauth-provider/metadata.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/metadata.ts
@@ -1,0 +1,295 @@
+import type {
+	AuthServerMetadata,
+	GrantType,
+	OIDCMetadata,
+	ResourceServerMetadata,
+	TokenEndpointAuthMethod,
+} from "../../oauth-2.1/types";
+import type { AuthContext, GenericEndpointContext } from "@better-auth/core";
+import { getJwtPlugin, getOAuthProviderPlugin } from "./utils";
+import type { OAuthOptions } from "./types";
+import type { JWSAlgorithms, JwtOptions } from "../jwt";
+import { BetterAuthError } from "@better-auth/core/error";
+import { logger } from "@better-auth/core/env";
+
+export function authServerMetadata(
+	ctx: GenericEndpointContext,
+	opts?: JwtOptions,
+	overrides?: {
+		scopes_supported?: AuthServerMetadata["scopes_supported"];
+		public_client_supported?: boolean;
+		grant_types_supported?: GrantType[];
+	},
+) {
+	const baseURL = ctx.context.baseURL;
+	const metadata: AuthServerMetadata = {
+		scopes_supported: overrides?.scopes_supported,
+		issuer: opts?.jwt?.issuer ?? baseURL,
+		authorization_endpoint: `${baseURL}/oauth2/authorize`,
+		token_endpoint: `${baseURL}/oauth2/token`,
+		jwks_uri: opts?.jwks?.remoteUrl ?? `${baseURL}/jwks`,
+		registration_endpoint: `${baseURL}/oauth2/register`,
+		introspection_endpoint: `${baseURL}/oauth2/introspect`,
+		revocation_endpoint: `${baseURL}/oauth2/revoke`,
+		response_types_supported:
+			overrides?.grant_types_supported &&
+			!overrides.grant_types_supported.includes("authorization_code")
+				? []
+				: ["code"],
+		response_modes_supported: ["query"],
+		grant_types_supported: overrides?.grant_types_supported ?? [
+			"authorization_code",
+			"client_credentials",
+			"refresh_token",
+		],
+		token_endpoint_auth_methods_supported: [
+			...(overrides?.public_client_supported
+				? (["none"] satisfies TokenEndpointAuthMethod[])
+				: []),
+			"client_secret_basic",
+			"client_secret_post",
+		],
+		introspection_endpoint_auth_methods_supported: [
+			"client_secret_basic",
+			"client_secret_post",
+		],
+		revocation_endpoint_auth_methods_supported: [
+			"client_secret_basic",
+			"client_secret_post",
+		],
+		code_challenge_methods_supported: ["S256"],
+	};
+	return metadata;
+}
+
+export function oidcServerMetadata(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions & { claims?: string[] },
+) {
+	const baseURL = ctx.context.baseURL;
+	const jwtPluginOptions = opts.disableJwtPlugin
+		? undefined
+		: getJwtPlugin(ctx.context).options;
+	const authMetadata = authServerMetadata(ctx, jwtPluginOptions, {
+		scopes_supported: opts.advertisedMetadata?.scopes_supported ?? opts.scopes,
+		public_client_supported: opts.allowUnauthenticatedClientRegistration,
+		grant_types_supported: opts.grantTypes,
+	});
+	const metadata: Omit<
+		OIDCMetadata,
+		"id_token_signing_alg_values_supported"
+	> & {
+		id_token_signing_alg_values_supported: JWSAlgorithms[] | ["HS256"];
+	} = {
+		...authMetadata,
+		claims_supported:
+			opts?.advertisedMetadata?.claims_supported ?? opts?.claims ?? [],
+		userinfo_endpoint: `${baseURL}/oauth2/userinfo`,
+		subject_types_supported: ["public"],
+		id_token_signing_alg_values_supported: jwtPluginOptions?.jwks?.keyPairConfig
+			?.alg
+			? [jwtPluginOptions?.jwks?.keyPairConfig?.alg]
+			: opts.disableJwtPlugin
+				? ["HS256"]
+				: ["EdDSA"],
+		acr_values_supported: ["urn:mace:incommon:iap:bronze"],
+	};
+	return metadata;
+}
+
+export function protectedResourceMetadata(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions,
+	overrides?: Partial<ResourceServerMetadata>,
+) {
+	const baseURL = ctx.context.baseURL;
+	const jwtPluginOptions = opts.disableJwtPlugin
+		? undefined
+		: getJwtPlugin(ctx.context).options;
+
+	return {
+		resource: jwtPluginOptions?.jwt?.audience ?? baseURL,
+		authorization_servers: [jwtPluginOptions?.jwt?.issuer ?? baseURL],
+		// Will allow all fields to be overwritten here since called via server endpoint (checking provided by oAuthProviderProtectedResourceMetadata)
+		...overrides,
+	} satisfies ResourceServerMetadata;
+}
+
+/**
+ * Provides an exportable `/.well-known/oauth-authorization-server`.
+ *
+ * Useful when basePath prevents the endpoint from being located at the root
+ * and must be provided manually.
+ *
+ * @external
+ */
+export const oauthProviderAuthServerMetadata = <
+	Auth extends {
+		api: {
+			getOAuthServerConfig: (...args: any) => any;
+		};
+	},
+>(
+	auth: Auth,
+	opts?: {
+		headers?: HeadersInit;
+	},
+) => {
+	return async (_request: Request) => {
+		const res = await auth.api.getOAuthServerConfig();
+		return new Response(JSON.stringify(res), {
+			status: 200,
+			headers: {
+				// We should cache here because it is unlikely this will
+				// change frequently and if it does shouldn't be more than
+				// for 15 seconds in a change period
+				"Cache-Control":
+					"public, max-age=15, stale-while-revalidate=15, stale-if-error=86400", // 15 sec
+				...opts?.headers,
+				"Content-Type": "application/json",
+			},
+		});
+	};
+};
+
+/**
+ * Provides an exportable `/.well-known/openid-configuration`.
+ *
+ * Useful when basePath prevents the endpoint from being located at the root
+ * and must be provided manually.
+ *
+ * @external
+ */
+export const oauthProviderOpenIdConfigMetadata = <
+	Auth extends {
+		api: {
+			getOpenIdConfig: (...args: any) => any;
+		};
+	},
+>(
+	auth: Auth,
+	opts?: {
+		headers?: HeadersInit;
+	},
+) => {
+	return async (_request: Request) => {
+		const res = await auth.api.getOpenIdConfig();
+		return new Response(JSON.stringify(res), {
+			status: 200,
+			headers: {
+				// We should cache here because it is unlikely this will
+				// change frequently and if it does shouldn't be more than
+				// for 15 seconds in a change period
+				"Cache-Control":
+					"public, max-age=15, stale-while-revalidate=15, stale-if-error=86400", // 15 sec
+				...opts?.headers,
+				"Content-Type": "application/json",
+			},
+		});
+	};
+};
+
+/**
+ * Provides an exportable `/.well-known/oauth-protected-resource`.
+ *
+ * Additionally checks scopes and configuration settings.
+ *
+ * @external
+ */
+export const oauthProviderProtectedResourceMetadata = <
+	Auth extends AuthContext & {
+		api: {
+			getOAuthProtectedResourceConfig: (...args: any) => any;
+		};
+	},
+>(
+	auth: Auth,
+	opts?: {
+		overrides?: Partial<ResourceServerMetadata>;
+		headers?: HeadersInit;
+		silenceWarnings?: {
+			oidcScopes?: boolean;
+		};
+		/** A list of scopes supported by other auth servers */
+		externalScopes?: string[];
+	},
+) => {
+	const oauthProviderPlugin = getOAuthProviderPlugin(auth);
+
+	// Resource server should not mention support for openid, only the AS should
+	if (opts?.overrides?.scopes_supported?.includes("openid")) {
+		throw new BetterAuthError(
+			"Only the Auth Server should utilize the openid scope",
+		);
+	}
+
+	// Provide scope warnings
+	if (opts?.overrides?.scopes_supported && !opts.silenceWarnings?.oidcScopes) {
+		for (const sc of opts?.overrides.scopes_supported) {
+			if (["profile", "email", "phone", "address"].includes(sc)) {
+				logger.warn(
+					`"${sc}" is typically restricted for the authorization server, a resource server shouldn't handle this scope`,
+				);
+			}
+		}
+	}
+
+	if (opts?.overrides?.authorization_servers?.length) {
+		const jwtPluginOptions = oauthProviderPlugin.options.disableJwtPlugin
+			? undefined
+			: getJwtPlugin(auth).options;
+		if (
+			!opts.overrides.authorization_servers.includes(
+				jwtPluginOptions?.jwt?.issuer ?? auth.baseURL,
+			)
+		) {
+			throw new BetterAuthError(
+				`authorization_servers list must at least contain ${jwtPluginOptions?.jwt?.issuer ?? auth.baseURL}`,
+			);
+		}
+	}
+
+	if (
+		opts?.externalScopes &&
+		(opts.overrides?.authorization_servers?.length ?? 0) <= 1
+	) {
+		throw new BetterAuthError(
+			"external scopes should not be provided with one authorization server",
+		);
+	}
+
+	// Check supported_scopes
+	const scopes = new Set([
+		...(opts?.externalScopes ?? []),
+		...(oauthProviderPlugin.options.scopes ?? []),
+	]);
+	if (opts?.overrides?.scopes_supported) {
+		for (const sc of opts.overrides.scopes_supported) {
+			if (!scopes?.has(sc)) {
+				throw new BetterAuthError(`${sc} is not supported by this auth server`);
+			}
+		}
+	}
+
+	return async (_request: Request) => {
+		const res = await auth.api.getOAuthProtectedResourceConfig({
+			body: opts?.overrides
+				? {
+						overrides: opts?.overrides,
+					}
+				: undefined,
+		});
+		return new Response(JSON.stringify(res), {
+			status: 200,
+			headers: {
+				// We should cache here because it is unlikely this will
+				// change frequently and if it does shouldn't be more than
+				// for 15 seconds in a change period
+				"Cache-Control":
+					"public, max-age=15, stale-while-revalidate=15, stale-if-error=86400", // 15 sec
+				...opts?.headers,
+				"Content-Type": "application/json",
+			},
+		});
+	};
+};

--- a/packages/better-auth/src/plugins/oauth-provider/oauth.test.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/oauth.test.ts
@@ -1,0 +1,1162 @@
+import { beforeAll, afterAll, afterEach, describe, it, expect } from "vitest";
+import { getTestInstance } from "../../test-utils/test-instance";
+import { oauthProvider } from "./oauth";
+import { genericOAuth, type GenericOAuthConfig } from "../generic-oauth";
+import type { OAuthClient } from "../../oauth-2.1/types";
+import { createAuthClient } from "../../client";
+import { oauthProviderClient } from "./client";
+import { genericOAuthClient } from "../generic-oauth/client";
+import { jwt } from "../jwt";
+import { verifyAccessToken } from "./verify";
+import { listen, type Listener } from "listhen";
+import { toNodeHandler } from "../../integrations/node";
+import { createLocalJWKSet, jwtVerify } from "jose";
+
+describe("oauth - init", () => {
+	it("should fail without the jwt plugin", async () => {
+		await expect(
+			getTestInstance({
+				plugins: [
+					oauthProvider({
+						loginPage: "/login",
+						consentPage: "/consent",
+						silenceWarnings: {
+							oauthAuthServerConfig: true,
+							openidConfig: true,
+						},
+					}),
+				],
+			}),
+		).rejects.toThrowError("jwt_config");
+	});
+
+	it("should pass without the jwt plugin and disableJwtPlugin set", async ({
+		expect,
+	}) => {
+		await expect(
+			getTestInstance({
+				plugins: [
+					oauthProvider({
+						loginPage: "/login",
+						consentPage: "/consent",
+						disableJwtPlugin: true,
+						silenceWarnings: {
+							oauthAuthServerConfig: true,
+							openidConfig: true,
+						},
+					}),
+				],
+			}),
+		).resolves.not.toThrowError();
+	});
+
+	it("should pass with correct plugins", async () => {
+		await expect(
+			getTestInstance({
+				plugins: [
+					jwt(),
+					oauthProvider({
+						loginPage: "/login",
+						consentPage: "/consent",
+						silenceWarnings: {
+							oauthAuthServerConfig: true,
+							openidConfig: true,
+						},
+					}),
+				],
+			}),
+		).resolves.not.toThrowError();
+	});
+});
+
+describe("oauth", async () => {
+	const port = 3001;
+	const authServerBaseUrl = `http://localhost:${port}`;
+	const rpBaseUrl = "http://localhost:5000";
+	const {
+		auth: authorizationServer,
+		signInWithTestUser,
+		customFetchImpl,
+		cookieSetter,
+		testUser,
+	} = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			jwt(),
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+		],
+	});
+	const authClient = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: {
+			customFetchImpl,
+		},
+	});
+
+	let server: Listener;
+	let oauthClient: OAuthClient | null;
+
+	const providerId = "test";
+	const redirectUri = `${rpBaseUrl}/api/auth/oauth2/callback/${providerId}`;
+
+	// Registers a confidential client application to work with
+	beforeAll(async () => {
+		// Opens the authorization server for testing with genericOAuth
+		server = await listen(
+			async (req, res) => {
+				// Adds openid-config as the endpoint manually since server-endpoint
+				if (req.url === "/.well-known/openid-configuration") {
+					const config = await authorizationServer.api.getOpenIdConfig();
+					res.setHeader("Content-Type", "application/json");
+					res.end(JSON.stringify(config));
+				} else {
+					toNodeHandler(authorizationServer.handler)(req, res);
+				}
+			},
+			{
+				port,
+			},
+		);
+
+		const { headers } = await signInWithTestUser();
+		const response = await authorizationServer.api.registerOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [redirectUri],
+				skip_consent: true,
+			},
+		});
+		expect(response?.client_id).toBeDefined();
+		expect(response?.user_id).toBeDefined();
+		expect(response?.client_secret).toBeDefined();
+		expect(response?.redirect_uris).toEqual([redirectUri]);
+		oauthClient = response;
+	});
+
+	afterAll(async () => {
+		await server.close();
+	});
+
+	async function createTestInstance(
+		config?: Omit<
+			GenericOAuthConfig,
+			"providerId" | "clientId" | "clientSecret"
+		>,
+	) {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+		return await getTestInstance({
+			// Used to trust callbackUrl in test
+			account: {
+				accountLinking: {
+					trustedProviders: [providerId],
+				},
+			},
+			plugins: [
+				genericOAuth({
+					config: [
+						{
+							scopes: ["openid", "profile", "email"],
+							...config,
+							providerId,
+							redirectURI: redirectUri,
+							authorizationUrl: config?.discoveryUrl
+								? undefined
+								: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
+							tokenUrl: config?.discoveryUrl
+								? undefined
+								: `${authServerBaseUrl}/api/auth/oauth2/token`,
+							userInfoUrl: config?.discoveryUrl
+								? undefined
+								: `${authServerBaseUrl}/api/auth/oauth2/userinfo`,
+							clientId: oauthClient.client_id,
+							clientSecret: oauthClient.client_secret,
+							pkce: true,
+						},
+					],
+				}),
+			],
+		});
+	}
+
+	// Tests if it is oauth2 compatible
+	it("should sign in using generic oauth plugin", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const { customFetchImpl: customFetchImplRP } = await createTestInstance();
+
+		const client = createAuthClient({
+			plugins: [genericOAuthClient()],
+			baseURL: rpBaseUrl,
+			fetchOptions: {
+				customFetchImpl: customFetchImplRP,
+			},
+		});
+		const headers = new Headers();
+		const data = await client.signIn.oauth2(
+			{
+				providerId,
+				callbackURL: "/success",
+			},
+			{
+				throw: true,
+				onSuccess: cookieSetter(headers),
+			},
+		);
+		expect(data.url).toContain(
+			`${authServerBaseUrl}/api/auth/oauth2/authorize`,
+		);
+		expect(data.url).toContain(`client_id=${oauthClient.client_id}`);
+
+		let loginRedirectUri = "";
+		const authClientHeaders = new Headers();
+		await authClient.$fetch(data.url, {
+			method: "GET",
+			onError(ctx) {
+				loginRedirectUri = ctx.response.headers.get("Location") || "";
+				cookieSetter(authClientHeaders)(ctx);
+			},
+		});
+		expect(loginRedirectUri).toContain("/login");
+		expect(loginRedirectUri).toContain(`client_id=${oauthClient.client_id}`);
+		expect(loginRedirectUri).toContain(
+			`redirect_uri=${encodeURIComponent(oauthClient?.redirect_uris?.at(0)!)}`,
+		);
+
+		authClientHeaders.append("accept", "application/json");
+		const res = await authClient.signIn.email(
+			{
+				email: testUser.email,
+				password: testUser.password,
+			},
+			{
+				headers: authClientHeaders,
+			},
+		);
+		expect(res.data?.redirect).toBeTruthy();
+		expect(res.data?.url).toContain(rpBaseUrl);
+
+		let callbackUrl = "";
+		await client.$fetch(res.data?.url!, {
+			method: "GET",
+			headers,
+			onError(context) {
+				callbackUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		expect(callbackUrl).toContain("/success");
+	});
+
+	it("should sign in using generic oauth discovery", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		// The RP (Relying Party) - the client
+		const { customFetchImpl: customFetchImplRP } = await createTestInstance({
+			discoveryUrl: `${authServerBaseUrl}/.well-known/openid-configuration`,
+		});
+
+		const client = createAuthClient({
+			plugins: [genericOAuthClient()],
+			baseURL: rpBaseUrl,
+			fetchOptions: {
+				customFetchImpl: customFetchImplRP,
+			},
+		});
+		const headers = new Headers();
+		const data = await client.signIn.oauth2(
+			{
+				providerId,
+				callbackURL: "/success",
+			},
+			{
+				throw: true,
+				onSuccess: cookieSetter(headers),
+			},
+		);
+		expect(data.url).toContain(
+			`${authServerBaseUrl}/api/auth/oauth2/authorize`,
+		);
+		expect(data.url).toContain(`client_id=${oauthClient.client_id}`);
+
+		let loginRedirectUri = "";
+		const authClientHeaders = new Headers();
+		await authClient.$fetch(data.url, {
+			method: "GET",
+			onError(ctx) {
+				loginRedirectUri = ctx.response.headers.get("Location") || "";
+				cookieSetter(authClientHeaders)(ctx);
+			},
+		});
+		expect(loginRedirectUri).toContain("/login");
+		expect(loginRedirectUri).toContain(`client_id=${oauthClient.client_id}`);
+		expect(loginRedirectUri).toContain(
+			`redirect_uri=${encodeURIComponent(oauthClient?.redirect_uris?.at(0)!)}`,
+		);
+
+		authClientHeaders.append("accept", "application/json");
+		const res = await authClient.signIn.email(
+			{
+				email: testUser.email,
+				password: testUser.password,
+			},
+			{
+				headers: authClientHeaders,
+			},
+		);
+		expect(res.data?.redirect).toBeTruthy();
+		expect(res.data?.url).toContain(rpBaseUrl);
+
+		let callbackURL = "";
+		await client.$fetch(res.data?.url!, {
+			method: "GET",
+			headers,
+			onError(ctx) {
+				callbackURL = ctx.response.headers.get("Location") || "";
+			},
+		});
+		expect(callbackURL).toContain("/success");
+	});
+});
+
+describe("oauth - prompt", async () => {
+	const port = 3001;
+	const authServerBaseUrl = `http://localhost:${port}`;
+	const rpBaseUrl = "http://localhost:5000";
+	const {
+		auth: authorizationServer,
+		signInWithTestUser,
+		customFetchImpl,
+		testUser,
+	} = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			jwt(),
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+		],
+	});
+
+	const { headers } = await signInWithTestUser();
+	const serverClient = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: {
+			customFetchImpl,
+			headers,
+		},
+	});
+
+	let server: Listener;
+	let oauthClient: OAuthClient | null;
+
+	const providerId = "test";
+	const redirectUri = `${rpBaseUrl}/api/auth/oauth2/callback/${providerId}`;
+
+	// Registers a confidential client application to work with
+	beforeAll(async () => {
+		// Opens the authorization server for testing with genericOAuth
+		server = await listen(
+			async (req, res) => {
+				// Adds openid-config as the endpoint manually since server-endpoint
+				if (req.url === "/.well-known/openid-configuration") {
+					const config = await authorizationServer.api.getOpenIdConfig();
+					res.setHeader("Content-Type", "application/json");
+					res.end(JSON.stringify(config));
+				} else {
+					toNodeHandler(authorizationServer.handler)(req, res);
+				}
+			},
+			{
+				port,
+			},
+		);
+
+		const response = await authorizationServer.api.registerOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [redirectUri],
+			},
+		});
+		expect(response?.client_id).toBeDefined();
+		expect(response?.user_id).toBeDefined();
+		expect(response?.client_secret).toBeDefined();
+		expect(response?.redirect_uris).toEqual([redirectUri]);
+		oauthClient = response;
+	});
+
+	afterAll(async () => {
+		await server.close();
+	});
+
+	async function createTestInstance(
+		config?: Omit<
+			GenericOAuthConfig,
+			"providerId" | "clientId" | "clientSecret"
+		>,
+	) {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+		return await getTestInstance({
+			// Used to trust callbackUrl in test
+			account: {
+				accountLinking: {
+					trustedProviders: [providerId],
+				},
+			},
+			plugins: [
+				genericOAuth({
+					config: [
+						{
+							scopes: ["openid", "profile", "email"],
+							...config,
+							providerId,
+							redirectURI: redirectUri,
+							authorizationUrl: config?.discoveryUrl
+								? undefined
+								: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
+							tokenUrl: config?.discoveryUrl
+								? undefined
+								: `${authServerBaseUrl}/api/auth/oauth2/token`,
+							userInfoUrl: config?.discoveryUrl
+								? undefined
+								: `${authServerBaseUrl}/api/auth/oauth2/userinfo`,
+							clientId: oauthClient.client_id,
+							clientSecret: oauthClient.client_secret,
+							pkce: true,
+						},
+					],
+				}),
+			],
+		});
+	}
+
+	it("login - should always redirect to login", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const { customFetchImpl: customFetchImplRP, cookieSetter } =
+			await createTestInstance({
+				prompt: "login",
+			});
+		const client = createAuthClient({
+			plugins: [genericOAuthClient()],
+			baseURL: rpBaseUrl,
+			fetchOptions: {
+				customFetchImpl: customFetchImplRP,
+			},
+		});
+
+		// Generate authorize url
+		const data = await client.signIn.oauth2(
+			{
+				providerId,
+				callbackURL: "/success",
+			},
+			{
+				throw: true,
+			},
+		);
+		expect(data.url).toContain(
+			`${authServerBaseUrl}/api/auth/oauth2/authorize`,
+		);
+		expect(data.url).toContain(`client_id=${oauthClient.client_id}`);
+
+		// Check for redirection to /login
+		let loginRedirectUri = "";
+		const newHeaders = new Headers();
+		await serverClient.$fetch(data.url, {
+			method: "GET",
+			headers: newHeaders,
+			onError(context) {
+				loginRedirectUri = context.response.headers.get("Location") || "";
+				cookieSetter(newHeaders)(context);
+			},
+		});
+		expect(loginRedirectUri).toContain("/login");
+		expect(loginRedirectUri).toContain(`client_id=${oauthClient.client_id}`);
+		expect(loginRedirectUri).toContain(
+			`redirect_uri=${encodeURIComponent(oauthClient?.redirect_uris?.at(0)!)}`,
+		);
+	});
+
+	it("consent - should sign in", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const { customFetchImpl: customFetchImplRP, cookieSetter } =
+			await createTestInstance({
+				prompt: "consent",
+			});
+		const client = createAuthClient({
+			plugins: [genericOAuthClient()],
+			baseURL: rpBaseUrl,
+			fetchOptions: {
+				customFetchImpl: customFetchImplRP,
+			},
+		});
+
+		// Generate authorize url
+		const oauthHeaders = new Headers();
+		const data = await client.signIn.oauth2(
+			{
+				providerId,
+				callbackURL: "/success",
+			},
+			{
+				throw: true,
+				onSuccess: cookieSetter(oauthHeaders),
+			},
+		);
+		expect(data.url).toContain(
+			`${authServerBaseUrl}/api/auth/oauth2/authorize`,
+		);
+		expect(data.url).toContain(`client_id=${oauthClient.client_id}`);
+		expect(data.url).toContain(`prompt=consent`);
+
+		// Check for redirection to /consent
+		let consentRedirectUri = "";
+		const newHeaders = new Headers();
+		await serverClient.$fetch(data.url, {
+			method: "GET",
+			onError(context) {
+				consentRedirectUri = context.response.headers.get("Location") || "";
+				expect(context.response.headers.get("set-cookie")).toContain(
+					"better-auth.oauth_consent_prompt=",
+				);
+				cookieSetter(newHeaders)(context);
+				newHeaders.append("Cookie", headers.get("Cookie") || "");
+			},
+		});
+		expect(consentRedirectUri).toContain(`/consent`);
+		expect(consentRedirectUri).toContain(`client_id=${oauthClient.client_id}`);
+		expect(consentRedirectUri).toContain(`scope=`);
+		expect(consentRedirectUri).toContain(`state=`);
+
+		// Give consent and obtain redirect callback
+		const res = await serverClient.oauth2.consent(
+			{
+				accept: true,
+			},
+			{
+				headers: newHeaders,
+				throw: true,
+				onResponse(context) {
+					expect(context.response.headers.get("set-cookie")).toContain(
+						"better-auth.oauth_consent_prompt=; Max-Age=0",
+					);
+				},
+			},
+		);
+		expect(res.redirect_uri).toContain(redirectUri);
+		expect(res.redirect_uri).toContain(`code=`);
+
+		let callbackURL = "";
+		await client.$fetch(res.redirect_uri, {
+			method: "GET",
+			headers: oauthHeaders,
+			onError(context) {
+				callbackURL = context.response.headers.get("Location") || "";
+			},
+		});
+		expect(callbackURL).toContain("/success");
+		expect(newHeaders.get("cookie")).toContain("better-auth.session_token=");
+	});
+
+	it("consent - should sign in given previous consent (see previous test)", async ({
+		expect,
+	}) => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const { customFetchImpl: customFetchImplRP, cookieSetter } =
+			await createTestInstance();
+		const client = createAuthClient({
+			plugins: [genericOAuthClient()],
+			baseURL: rpBaseUrl,
+			fetchOptions: {
+				customFetchImpl: customFetchImplRP,
+			},
+		});
+
+		// Generate authorize url
+		const oauthHeaders = new Headers();
+		const data = await client.signIn.oauth2(
+			{
+				providerId,
+				callbackURL: "/success",
+			},
+			{
+				throw: true,
+				onSuccess: cookieSetter(oauthHeaders),
+			},
+		);
+		expect(data.url).toContain(
+			`${authServerBaseUrl}/api/auth/oauth2/authorize`,
+		);
+		expect(data.url).toContain(`client_id=${oauthClient.client_id}`);
+
+		// No redirect and user should get code
+		let callbackRedirectUrl = "";
+		const newHeaders = new Headers();
+		await serverClient.$fetch(data.url, {
+			method: "GET",
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+				cookieSetter(newHeaders)(context);
+				newHeaders.append("Cookie", headers.get("Cookie") || "");
+			},
+		});
+		expect(callbackRedirectUrl).toContain(redirectUri);
+		expect(callbackRedirectUrl).toContain("code=");
+		expect(callbackRedirectUrl).toContain("state=");
+
+		// Code exchange should be successful
+		let callbackURL = "";
+		await client.$fetch(callbackRedirectUrl, {
+			method: "GET",
+			headers: oauthHeaders,
+			onError(context) {
+				callbackURL = context.response.headers.get("Location") || "";
+			},
+		});
+		expect(callbackURL).toContain("/success");
+	});
+
+	it("consent - should consent again given new scope", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const { customFetchImpl: customFetchImplRP, cookieSetter } =
+			await createTestInstance({
+				scopes: ["openid", "profile", "email", "offline_access"],
+			});
+		const client = createAuthClient({
+			plugins: [genericOAuthClient()],
+			baseURL: rpBaseUrl,
+			fetchOptions: {
+				customFetchImpl: customFetchImplRP,
+			},
+		});
+
+		// Generate authorize url
+		const oauthHeaders = new Headers();
+		const data = await client.signIn.oauth2(
+			{
+				providerId,
+				callbackURL: "/success",
+			},
+			{
+				throw: true,
+				onSuccess: cookieSetter(oauthHeaders),
+			},
+		);
+		expect(data.url).toContain(
+			`${authServerBaseUrl}/api/auth/oauth2/authorize`,
+		);
+		expect(data.url).toContain(`client_id=${oauthClient.client_id}`);
+
+		// Check for redirection to /consent
+		let consentRedirectUri = "";
+		const newHeaders = new Headers();
+		await serverClient.$fetch(data.url, {
+			method: "GET",
+			onError(context) {
+				consentRedirectUri = context.response.headers.get("Location") || "";
+				expect(context.response.headers.get("set-cookie")).toContain(
+					"better-auth.oauth_consent_prompt=",
+				);
+				cookieSetter(newHeaders)(context);
+				newHeaders.append("Cookie", headers.get("Cookie") || "");
+			},
+		});
+		expect(consentRedirectUri).toContain(`/consent`);
+		expect(consentRedirectUri).toContain(`client_id=${oauthClient.client_id}`);
+		expect(consentRedirectUri).toContain(`scope=`);
+		expect(consentRedirectUri).toContain(`state=`);
+	});
+});
+
+describe("oauth - config", () => {
+	const port = 3002;
+	const authServerBaseUrl = `http://localhost:${port}`;
+	const authServerUrl = `${authServerBaseUrl}/api/auth`;
+	const rpBaseUrl = "http://localhost:5000";
+	const providerId = "test";
+	const redirectUri = `${rpBaseUrl}/api/auth/oauth2/callback/${providerId}`;
+
+	let server: Listener;
+	let oauthClient: OAuthClient | null;
+
+	afterEach(async () => {
+		if (server) {
+			await server.close();
+		}
+	});
+
+	/** Create a test client */
+	async function createTestInstance(
+		config?: Omit<
+			GenericOAuthConfig,
+			"providerId" | "clientId" | "clientSecret"
+		>,
+	) {
+		if (!oauthClient?.client_id) {
+			throw Error("beforeAll not run properly");
+		}
+		return await getTestInstance({
+			// Used to trust callbackUrl in test
+			account: {
+				accountLinking: {
+					trustedProviders: [providerId],
+				},
+			},
+			plugins: [
+				genericOAuth({
+					config: [
+						{
+							scopes: ["openid", "profile", "email"],
+							...config,
+							providerId,
+							redirectURI: redirectUri,
+							authorizationUrl: config?.discoveryUrl
+								? undefined
+								: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
+							tokenUrl: config?.discoveryUrl
+								? undefined
+								: `${authServerBaseUrl}/api/auth/oauth2/token`,
+							userInfoUrl: config?.discoveryUrl
+								? undefined
+								: `${authServerBaseUrl}/api/auth/oauth2/userinfo`,
+							clientId: oauthClient.client_id,
+							clientSecret: oauthClient?.client_secret,
+							pkce: true,
+						},
+					],
+				}),
+			],
+		});
+	}
+
+	it.each([
+		{
+			storeClientSecret: undefined,
+		},
+		{
+			storeClientSecret: "hashed",
+		},
+	] as const)(
+		"storeClientSecret: $storeClientSecret",
+		async ({ storeClientSecret }) => {
+			const {
+				auth: authorizationServer,
+				signInWithTestUser,
+				customFetchImpl,
+			} = await getTestInstance({
+				baseURL: authServerBaseUrl,
+				plugins: [
+					oauthProvider({
+						loginPage: "/login",
+						consentPage: "/consent",
+						storeClientSecret,
+						silenceWarnings: {
+							oauthAuthServerConfig: true,
+							openidConfig: true,
+						},
+					}),
+					jwt(),
+				],
+			});
+			const { headers } = await signInWithTestUser();
+			const serverClient = createAuthClient({
+				plugins: [oauthProviderClient()],
+				baseURL: authServerBaseUrl,
+				fetchOptions: {
+					customFetchImpl,
+					headers,
+				},
+			});
+
+			server = await listen(toNodeHandler(authorizationServer.handler), {
+				port,
+			});
+
+			const createdClient = await authorizationServer.api.registerOAuthClient({
+				headers,
+				body: {
+					redirect_uris: [redirectUri],
+					skip_consent: true,
+				},
+			});
+			expect(createdClient?.client_id).toBeDefined();
+			expect(createdClient?.user_id).toBeDefined();
+			expect(createdClient?.client_secret).toBeDefined();
+			expect(createdClient?.redirect_uris).toEqual([redirectUri]);
+			oauthClient = createdClient;
+
+			// The RP (Relying Party) - the client application
+			const { customFetchImpl: customFetchImplRP, cookieSetter } =
+				await createTestInstance();
+
+			const client = createAuthClient({
+				plugins: [genericOAuthClient()],
+				baseURL: rpBaseUrl,
+				fetchOptions: {
+					customFetchImpl: customFetchImplRP,
+				},
+			});
+			const oauthHeaders = new Headers();
+			const data = await client.signIn.oauth2(
+				{
+					providerId: "test",
+					callbackURL: "/success",
+				},
+				{
+					throw: true,
+					onSuccess: cookieSetter(oauthHeaders),
+				},
+			);
+			expect(data.url).toContain(
+				`${authServerBaseUrl}/api/auth/oauth2/authorize`,
+			);
+			expect(data.url).toContain(`client_id=${oauthClient?.client_id}`);
+
+			let redirectUriResponse = "";
+			await serverClient.$fetch(data.url, {
+				method: "GET",
+				onError(context) {
+					redirectUriResponse = context.response.headers.get("Location") || "";
+				},
+			});
+			expect(redirectUriResponse).toContain(redirectUri);
+			expect(redirectUriResponse).toContain("code=");
+
+			let callbackURL = "";
+			await client.$fetch(redirectUriResponse, {
+				method: "GET",
+				headers: oauthHeaders,
+				onError(context) {
+					callbackURL = context.response.headers.get("Location") || "";
+				},
+			});
+			expect(callbackURL).toContain("/success");
+		},
+	);
+
+	it.each([
+		{
+			storeClientSecret: "encrypted",
+		},
+	] as const)(
+		"storeClientSecret: $storeClientSecret",
+		async ({ storeClientSecret }) => {
+			const {
+				auth: authorizationServer,
+				signInWithTestUser,
+				customFetchImpl,
+				cookieSetter,
+			} = await getTestInstance({
+				baseURL: authServerBaseUrl,
+				plugins: [
+					oauthProvider({
+						loginPage: "/login",
+						consentPage: "/consent",
+						storeClientSecret,
+						disableJwtPlugin: true,
+						silenceWarnings: {
+							oauthAuthServerConfig: true,
+							openidConfig: true,
+						},
+					}),
+				],
+			});
+			const { headers } = await signInWithTestUser();
+			const serverClient = createAuthClient({
+				plugins: [oauthProviderClient()],
+				baseURL: authServerBaseUrl,
+				fetchOptions: {
+					customFetchImpl,
+					headers,
+				},
+			});
+
+			server = await listen(toNodeHandler(authorizationServer.handler), {
+				port,
+			});
+
+			const createdClient = await authorizationServer.api.registerOAuthClient({
+				headers,
+				body: {
+					redirect_uris: [redirectUri],
+					skip_consent: true,
+				},
+			});
+			expect(createdClient?.client_id).toBeDefined();
+			expect(createdClient?.user_id).toBeDefined();
+			expect(createdClient?.client_secret).toBeDefined();
+			expect(createdClient?.redirect_uris).toEqual([redirectUri]);
+			oauthClient = createdClient;
+
+			// The RP (Relying Party) - the client application
+			const { customFetchImpl: customFetchImplRP } = await createTestInstance();
+
+			const client = createAuthClient({
+				plugins: [genericOAuthClient()],
+				baseURL: rpBaseUrl,
+				fetchOptions: {
+					customFetchImpl: customFetchImplRP,
+				},
+			});
+			const oauthHeaders = new Headers();
+			const data = await client.signIn.oauth2(
+				{
+					providerId: "test",
+					callbackURL: "/success",
+				},
+				{
+					throw: true,
+					onSuccess: cookieSetter(oauthHeaders),
+				},
+			);
+			expect(data.url).toContain(
+				`${authServerBaseUrl}/api/auth/oauth2/authorize`,
+			);
+			expect(data.url).toContain(`client_id=${oauthClient?.client_id}`);
+
+			let redirectUriResponse = "";
+			await serverClient.$fetch(data.url, {
+				method: "GET",
+				onError(context) {
+					redirectUriResponse = context.response.headers.get("Location") || "";
+				},
+			});
+			expect(redirectUriResponse).toContain(redirectUri);
+			expect(redirectUriResponse).toContain("code=");
+
+			let callbackURL = "";
+			await client.$fetch(redirectUriResponse, {
+				method: "GET",
+				headers: oauthHeaders,
+				onError(context) {
+					callbackURL = context.response.headers.get("Location") || "";
+				},
+			});
+			expect(callbackURL).toContain("/success");
+		},
+	);
+
+	it.each([
+		{ disableJwtPlugin: false, publicClient: false, resource: false },
+		{ disableJwtPlugin: true, publicClient: false, resource: false },
+		{ disableJwtPlugin: false, publicClient: true, resource: false },
+		{ disableJwtPlugin: true, publicClient: true, resource: false },
+		{ disableJwtPlugin: false, publicClient: false, resource: true },
+		{ disableJwtPlugin: true, publicClient: false, resource: true },
+		{ disableJwtPlugin: false, publicClient: true, resource: true },
+		{ disableJwtPlugin: true, publicClient: true, resource: true },
+	])(
+		"token return type - disableJwtPlugin: $disableJwtPlugin, publicClient: $publicClient, resource: $resource",
+		async ({ disableJwtPlugin, publicClient, resource }) => {
+			const validAudience = disableJwtPlugin
+				? `${authServerBaseUrl}/api/auth`
+				: "https://api.example.com";
+			const {
+				auth: authorizationServer,
+				cookieSetter,
+				signInWithTestUser,
+				customFetchImpl,
+			} = await getTestInstance({
+				baseURL: authServerBaseUrl,
+				plugins: [
+					oauthProvider({
+						loginPage: "/login",
+						consentPage: "/consent",
+						disableJwtPlugin: disableJwtPlugin,
+						silenceWarnings: {
+							oauthAuthServerConfig: true,
+							openidConfig: true,
+						},
+					}),
+					...(disableJwtPlugin
+						? []
+						: [
+								jwt({
+									jwt: {
+										audience: resource ? validAudience : undefined,
+									},
+								}),
+							]),
+				],
+			});
+			const { headers, user } = await signInWithTestUser();
+			const serverClient = createAuthClient({
+				plugins: [oauthProviderClient()],
+				baseURL: authServerBaseUrl,
+				fetchOptions: {
+					customFetchImpl,
+					headers,
+				},
+			});
+			server = await listen(toNodeHandler(authorizationServer.handler), {
+				port,
+			});
+
+			const createdClient = await authorizationServer.api.registerOAuthClient({
+				headers,
+				body: {
+					redirect_uris: [redirectUri],
+					token_endpoint_auth_method: publicClient ? "none" : undefined,
+					skip_consent: true,
+				},
+			});
+			expect(createdClient?.client_id).toBeDefined();
+			expect(createdClient?.user_id).toBeDefined();
+			if (publicClient) {
+				expect(createdClient?.client_secret).toBeUndefined();
+			} else {
+				expect(createdClient?.client_secret).toBeDefined();
+			}
+			expect(createdClient?.redirect_uris).toEqual([redirectUri]);
+			oauthClient = createdClient;
+
+			// The RP (Relying Party) - the client application
+			const { customFetchImpl: customFetchImplRP } = await createTestInstance({
+				tokenUrlParams: resource
+					? {
+							resource: validAudience,
+						}
+					: undefined,
+			});
+
+			const client = createAuthClient({
+				plugins: [genericOAuthClient()],
+				baseURL: rpBaseUrl,
+				fetchOptions: {
+					customFetchImpl: customFetchImplRP,
+				},
+			});
+			const oauthHeaders = new Headers();
+			const data = await client.signIn.oauth2(
+				{
+					providerId: "test",
+					callbackURL: "/success",
+				},
+				{
+					throw: true,
+					onSuccess: cookieSetter(oauthHeaders),
+				},
+			);
+			expect(data.url).toContain(`${authServerUrl}/oauth2/authorize`);
+			expect(data.url).toContain(`client_id=${oauthClient?.client_id}`);
+
+			let redirectUriResponse = "";
+			await serverClient.$fetch(data.url, {
+				method: "GET",
+				onError(context) {
+					redirectUriResponse = context.response.headers.get("Location") || "";
+				},
+			});
+			expect(redirectUriResponse).toContain(redirectUri);
+			expect(redirectUriResponse).toContain("code=");
+
+			let authToken: string | undefined;
+			let callbackURL: string | undefined;
+			await client.$fetch(redirectUriResponse, {
+				method: "GET",
+				headers: oauthHeaders,
+				onError(context) {
+					callbackURL = context.response.headers.get("Location") ?? undefined;
+					authToken =
+						context.response.headers.get("set-auth-token") ?? undefined;
+				},
+			});
+			expect(callbackURL).toContain("/success");
+
+			// Get and check tokens
+			const tokens = await client.getAccessToken(
+				{ providerId: "test", userId: user.id },
+				{
+					auth: {
+						type: "Bearer",
+						token: authToken,
+					},
+				},
+			);
+
+			// Check for access tokens
+			expect(tokens.data?.accessToken).toBeDefined();
+			if (publicClient && !(resource && !disableJwtPlugin)) {
+				await expect(
+					verifyAccessToken(tokens.data?.accessToken!, {
+						verifyOptions: {
+							audience: validAudience,
+							issuer: authServerUrl,
+						},
+						jwksUrl: disableJwtPlugin ? undefined : `${authServerUrl}/jwks`,
+					}),
+				).rejects.toThrowError();
+			} else {
+				await verifyAccessToken(tokens.data?.accessToken!, {
+					verifyOptions: {
+						audience: validAudience,
+						issuer: authServerUrl,
+					},
+					jwksUrl: disableJwtPlugin ? undefined : `${authServerUrl}/jwks`,
+					remoteVerify: publicClient
+						? undefined
+						: {
+								introspectUrl: `${authServerUrl}/oauth2/introspect`,
+								clientId: createdClient?.client_id!,
+								clientSecret: createdClient?.client_secret!,
+							},
+				});
+			}
+
+			// Check id token tokens
+			if (disableJwtPlugin) {
+				if (!publicClient) {
+					const clientSecret = oauthClient?.client_secret;
+					const checkSignature = await jwtVerify(
+						tokens.data?.idToken!,
+						new TextEncoder().encode(clientSecret),
+						{
+							algorithms: ["HS256"],
+						},
+					);
+					expect(checkSignature).toBeDefined();
+				}
+			} else {
+				expect(tokens.data?.idToken).toBeDefined();
+				const jwks = await authorizationServer.api.getJwks();
+				const jwkSet = createLocalJWKSet(jwks);
+				const checkSignature = await jwtVerify(tokens.data?.idToken!, jwkSet, {
+					algorithms: ["EdDSA"],
+				});
+				expect(checkSignature).toBeDefined();
+			}
+		},
+	);
+});

--- a/packages/better-auth/src/plugins/oauth-provider/oauth.test.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/oauth.test.ts
@@ -127,7 +127,7 @@ describe("oauth", async () => {
 		);
 
 		const { headers } = await signInWithTestUser();
-		const response = await authorizationServer.api.registerOAuthClient({
+		const response = await authorizationServer.api.createOAuthClient({
 			headers,
 			body: {
 				redirect_uris: [redirectUri],
@@ -390,7 +390,7 @@ describe("oauth - prompt", async () => {
 			},
 		);
 
-		const response = await authorizationServer.api.registerOAuthClient({
+		const response = await authorizationServer.api.createOAuthClient({
 			headers,
 			body: {
 				redirect_uris: [redirectUri],
@@ -804,7 +804,7 @@ describe("oauth - config", () => {
 				port,
 			});
 
-			const createdClient = await authorizationServer.api.registerOAuthClient({
+			const createdClient = await authorizationServer.api.createOAuthClient({
 				headers,
 				body: {
 					redirect_uris: [redirectUri],
@@ -907,7 +907,7 @@ describe("oauth - config", () => {
 				port,
 			});
 
-			const createdClient = await authorizationServer.api.registerOAuthClient({
+			const createdClient = await authorizationServer.api.createOAuthClient({
 				headers,
 				body: {
 					redirect_uris: [redirectUri],
@@ -1024,7 +1024,7 @@ describe("oauth - config", () => {
 				port,
 			});
 
-			const createdClient = await authorizationServer.api.registerOAuthClient({
+			const createdClient = await authorizationServer.api.createOAuthClient({
 				headers,
 				body: {
 					redirect_uris: [redirectUri],

--- a/packages/better-auth/src/plugins/oauth-provider/oauth.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/oauth.ts
@@ -1,0 +1,1383 @@
+import { z } from "zod";
+import {
+	APIError,
+	createAuthEndpoint,
+	createAuthMiddleware,
+	sessionMiddleware,
+} from "../../api";
+import type { BetterAuthPlugin } from "../../types";
+import { parseSetCookieHeader } from "../../cookies";
+import { schema } from "./schema";
+import type { OAuthOptions } from "./types";
+import { authorizeEndpoint } from "./authorize";
+import { consentEndpoint } from "./consent";
+import { tokenEndpoint } from "./token";
+import { userInfoEndpoint } from "./userinfo";
+import { mergeSchema } from "../../db";
+import { dynamicRegisterEndpoint, registerOAuthClient } from "./register";
+import {
+	authServerMetadata,
+	oidcServerMetadata,
+	protectedResourceMetadata,
+} from "./metadata";
+import { getJwtPlugin } from "./utils";
+import { introspectEndpoint } from "./introspect";
+import { revokeEndpoint } from "./revoke";
+import { BetterAuthError } from "@better-auth/core/error";
+import { logger } from "@better-auth/core/env";
+import type { ResourceServerMetadata } from "../../oauth-2.1/types";
+import { introspectVerifyEndpoint } from "./verify";
+
+/**
+ * oAuth 2.1 provider plugin for Better Auth.
+ *
+ * @see https://better-auth.com/docs/plugins/oauth-provider
+ * @param options - The options for the oAuth Provider plugin.
+ * @returns A Better Auth plugin.
+ */
+export const oauthProvider = (options: OAuthOptions) => {
+	let clientRegistrationAllowedScopes = options.clientRegistrationAllowedScopes;
+	if (options.clientRegistrationDefaultScopes) {
+		clientRegistrationAllowedScopes = clientRegistrationAllowedScopes
+			? [
+					...clientRegistrationAllowedScopes,
+					...options.clientRegistrationDefaultScopes,
+				]
+			: [...options.clientRegistrationDefaultScopes];
+	}
+
+	// Validate scopes
+	const scopes = new Set(
+		(options.scopes ?? ["openid", "profile", "email", "offline_access"]).filter(
+			(val) => val.length,
+		),
+	);
+	if (clientRegistrationAllowedScopes) {
+		for (const sc of clientRegistrationAllowedScopes) {
+			if (!scopes.has(sc)) {
+				throw new BetterAuthError(
+					`clientRegistrationAllowedScope ${sc} not found in scopes`,
+				);
+			}
+		}
+	}
+	for (const sc of options.advertisedMetadata?.scopes_supported ?? []) {
+		if (!scopes?.has(sc)) {
+			throw new BetterAuthError(
+				`advertisedMetadata.scopes_supported ${sc} not found in scopes`,
+			);
+		}
+	}
+
+	// Validate claims
+	const claims = new Set([
+		"sub",
+		"iss",
+		"aud",
+		"exp",
+		"iat",
+		"sid",
+		"scope",
+		"azp",
+		...(scopes.has("email") ? ["email", "email_verified"] : []),
+		...(scopes.has("profile")
+			? ["name", "picture", "family_name", "given_name"]
+			: []),
+		...(options?.customClaims?.filter((val) => val.length) ?? []),
+	]);
+	for (const cl of options.advertisedMetadata?.claims_supported ?? []) {
+		if (!claims?.has(cl)) {
+			throw new BetterAuthError(
+				`advertisedMetadata.claims_supported ${cl} not found in claims`,
+			);
+		}
+	}
+
+	const opts: OAuthOptions & { claims?: string[] } = {
+		codeExpiresIn: 600, // 10 min
+		accessTokenExpiresIn: 3600, // 1 hour
+		m2mAccessTokenExpiresIn: 3600, // 1 hour
+		refreshTokenExpiresIn: 2592000, // 30 days
+		allowUnauthenticatedClientRegistration: false,
+		allowDynamicClientRegistration: false,
+		disableJwtPlugin: false,
+		storeClientSecret: options.disableJwtPlugin ? "encrypted" : "hashed",
+		storeTokens: "hashed",
+		grantTypes: ["authorization_code", "client_credentials", "refresh_token"],
+		...options,
+		scopes: Array.from(scopes),
+		claims: Array.from(claims),
+		clientRegistrationAllowedScopes,
+	};
+
+	// TODO: device_code grant also allows for refresh tokens
+	if (
+		opts.grantTypes &&
+		opts.grantTypes.includes("refresh_token") &&
+		!opts.grantTypes.includes("authorization_code")
+	) {
+		throw new BetterAuthError(
+			"refresh_token grant requires authorization_code grant",
+		);
+	}
+
+	// Both encode and decode refresh tokens must be defined if one is defined
+	if (
+		(opts.encodeRefreshToken && !opts.decodeRefreshToken) ||
+		(!opts.encodeRefreshToken && opts.decodeRefreshToken)
+	) {
+		throw new BetterAuthError(
+			"encodeRefreshToken and decodeRefreshToken should both be defined",
+		);
+	}
+
+	if (
+		opts.disableJwtPlugin &&
+		(opts.storeClientSecret === "hashed" ||
+			(typeof opts.storeClientSecret === "object" &&
+				"hash" in opts.storeClientSecret))
+	) {
+		throw new BetterAuthError(
+			"unable to store hashed secrets because id tokens will be signed with secret",
+		);
+	}
+
+	if (
+		!opts.disableJwtPlugin &&
+		(opts.storeClientSecret === "encrypted" ||
+			(typeof opts.storeClientSecret === "object" &&
+				("encrypt" in opts.storeClientSecret ||
+					"decrypt" in opts.storeClientSecret)))
+	) {
+		throw new BetterAuthError(
+			"encryption method not recommended, please use 'hashed' or the 'hash' function",
+		);
+	}
+
+	return {
+		id: "oauthProvider",
+		options: opts,
+		init: (ctx) => {
+			// Check for jwt plugin registration
+			if (!opts.disableJwtPlugin) {
+				const jwtPlugin = getJwtPlugin(ctx);
+				const jwtPluginOptions = jwtPlugin.options;
+
+				// Issuer and well-known endpoint checks
+				const issuer = jwtPluginOptions?.jwt?.issuer ?? ctx.baseURL;
+				const issuerPath = new URL(issuer).pathname;
+				// oAuth Server Config
+				if (
+					!opts.silenceWarnings?.oauthAuthServerConfig &&
+					!(ctx.options.basePath === "/" && issuerPath === "/")
+				) {
+					logger.warn(
+						`Please ensure '/.well-known/oauth-authorization-server${issuerPath === "/" ? "" : issuerPath}' exists. Upon completion, clear with silenceWarnings.oauthAuthServerConfig.`,
+					);
+				}
+				// OpenId Config
+				if (
+					!opts.silenceWarnings?.openidConfig &&
+					ctx.options.basePath !== issuerPath &&
+					opts.scopes?.includes("openid")
+				) {
+					logger.warn(
+						`Please ensure '${issuerPath}${issuerPath.endsWith("/") ? "" : "/"}.well-known/openid-configuration' exists. Upon completion, clear with silenceWarnings.openidConfig.`,
+					);
+				}
+			}
+		},
+		hooks: {
+			after: [
+				/**
+				 * If a session cookie is being set (ie user has logged in)
+				 * complete response with /authorize request.
+				 */
+				{
+					matcher(ctx) {
+						return parseSetCookieHeader(
+							ctx.context.responseHeaders?.get("set-cookie") || "",
+						).has(ctx.context.authCookies.sessionToken.name);
+					},
+					handler: createAuthMiddleware(async (ctx) => {
+						// Obtain original prompt
+						const { name: loginPromptCookieName } =
+							ctx.context.createAuthCookie("oauth_login_prompt");
+						const cookie = await ctx.getSignedCookie(
+							loginPromptCookieName,
+							ctx.context.secret,
+						);
+
+						// Check if session cookie is being set and obtain its session (needed in context)
+						const cookieName = ctx.context.authCookies.sessionToken.name;
+						const parsedSetCookieHeader = parseSetCookieHeader(
+							ctx.context.responseHeaders?.get("set-cookie") || "",
+						);
+						const sessionToken = parsedSetCookieHeader
+							.get(cookieName)
+							?.value?.split(".")[0];
+						if (!cookie || !sessionToken) return;
+						const session =
+							await ctx.context.internalAdapter.findSession(sessionToken);
+						if (!session) return;
+						ctx.context.session = session;
+
+						// Continue with authorization request by using the initial prompt
+						// but clearing the login prompt cookie if forced login prompt
+						ctx.query = JSON.parse(cookie);
+						if (ctx.query?.prompt === "login") {
+							ctx.query!.prompt = undefined; // clear login prompt parameter
+						}
+						ctx.setCookie(loginPromptCookieName, "", {
+							maxAge: 0,
+						});
+						return await authorizeEndpoint(ctx, opts);
+					}),
+				},
+			],
+		},
+		endpoints: {
+			/**
+			 * A server_only endpoint that helps provide the
+			 * oAuth Server configuration at the well-known endpoint.
+			 *
+			 * Provided at /.well-known/oauth-authorization-server/[issuer-path]
+			 * (root if no issuer-path).
+			 */
+			getOAuthServerConfig: createAuthEndpoint(
+				"/.well-known/oauth-authorization-server/server",
+				{
+					method: "GET",
+					metadata: {
+						SERVER_ONLY: true,
+					},
+				},
+				async (ctx) => {
+					if (opts.scopes && opts.scopes.includes("openid")) {
+						const metadata = oidcServerMetadata(ctx, opts);
+						return ctx.json(metadata);
+					} else {
+						const jwtPluginOptions = opts.disableJwtPlugin
+							? undefined
+							: getJwtPlugin(ctx.context).options;
+						const authMetadata = authServerMetadata(ctx, jwtPluginOptions, {
+							scopes_supported:
+								opts.advertisedMetadata?.scopes_supported ?? opts.scopes,
+						});
+						return ctx.json(authMetadata);
+					}
+				},
+			),
+			/**
+			 * A server_only endpoint that helps provide the
+			 * OpenId configuration at the well-known endpoint.
+			 *
+			 * Provided at [issuer-path]/.well-known/openid-configuration
+			 * (root if no issuer-path).
+			 */
+			getOpenIdConfig: createAuthEndpoint(
+				"/.well-known/openid-configuration/server",
+				{
+					method: "GET",
+					metadata: {
+						SERVER_ONLY: true,
+					},
+				},
+				async (ctx) => {
+					if (opts.scopes && !opts.scopes.includes("openid")) {
+						throw new APIError("NOT_FOUND");
+					}
+					const metadata = oidcServerMetadata(ctx, opts);
+					return ctx.json(metadata);
+				},
+			),
+			/**
+			 * An authorization server does not typically publish
+			 * the `/.well-known/oauth-protected-resource` themselves.
+			 * Thus, we provide a server-only endpoint help set up
+			 * your protected resource metadata.
+			 *
+			 * If you have your APIs hosted on a different domain,
+			 * post the metadata yourself without the need of the full
+			 * better-auth library/configuration.
+			 *
+			 * @see https://datatracker.ietf.org/doc/html/rfc8414#section-2
+			 */
+			getOAuthProtectedResourceConfig: createAuthEndpoint(
+				"/.well-known/oauth-protected-resource/server",
+				{
+					method: "POST",
+					metadata: {
+						SERVER_ONLY: true,
+						$Infer: {
+							body: {} as
+								| {
+										overrides?: Partial<ResourceServerMetadata>;
+								  }
+								| undefined,
+						},
+					},
+					body: z
+						.object({
+							overrides: z.record(z.string(), z.any()),
+						})
+						.optional(),
+				},
+				async (ctx) => {
+					const overrides = ctx.body?.overrides;
+					const metadata = protectedResourceMetadata(ctx, opts, overrides);
+					return ctx.json(metadata);
+				},
+			),
+			oauth2Authorize: createAuthEndpoint(
+				"/oauth2/authorize",
+				{
+					method: "GET",
+					query: z.object({
+						response_type: z.enum(["code"]),
+						client_id: z.string(),
+						redirect_uri: z.string().optional(),
+						scope: z.string().optional(),
+						state: z.string().optional(),
+						code_challenge: z.string().optional(),
+						code_challenge_method: z.enum(["S256"]).optional(),
+						nonce: z.string().optional(),
+						prompt: z.enum(["consent", "login"]).optional(),
+					}),
+					metadata: {
+						openapi: {
+							description: "Authorize an OAuth2 request",
+							parameters: [
+								{
+									name: "response_type",
+									in: "query",
+									required: true,
+									schema: { type: "string" },
+									description: "OAuth2 response type (e.g., 'code')",
+								},
+								{
+									name: "client_id",
+									in: "query",
+									required: true,
+									schema: { type: "string" },
+									description: "OAuth2 client ID",
+								},
+								{
+									name: "redirect_uri",
+									in: "query",
+									required: false,
+									schema: { type: "string", format: "uri" },
+									description: "OAuth2 redirect URI",
+								},
+								{
+									name: "scope",
+									in: "query",
+									required: false,
+									schema: { type: "string" },
+									description: "OAuth2 scopes (space-separated)",
+								},
+								{
+									name: "state",
+									in: "query",
+									required: false,
+									schema: { type: "string" },
+									description: "OAuth2 state parameter",
+								},
+								{
+									name: "code_challenge",
+									in: "query",
+									required: false,
+									schema: { type: "string" },
+									description: "PKCE code challenge",
+								},
+								{
+									name: "code_challenge_method",
+									in: "query",
+									required: false,
+									schema: { type: "string" },
+									description: "PKCE code challenge method",
+								},
+								{
+									name: "nonce",
+									in: "query",
+									required: false,
+									schema: { type: "string" },
+									description: "OpenID Connect nonce",
+								},
+								{
+									name: "prompt",
+									in: "query",
+									required: false,
+									schema: { type: "string" },
+									description: "OAuth2 prompt parameter",
+								},
+							],
+							responses: {
+								"302": {
+									description: "Redirect to client with code or error",
+									headers: {
+										Location: {
+											description: "Redirect URI with code or error",
+											schema: { type: "string", format: "uri" },
+										},
+									},
+								},
+								"400": {
+									description: "Invalid request",
+									content: {
+										"application/json": {
+											schema: {
+												type: "object",
+												properties: {
+													error: { type: "string" },
+													error_description: { type: "string" },
+													state: { type: "string" },
+												},
+												required: ["error"],
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				async (ctx) => {
+					return authorizeEndpoint(ctx, opts);
+				},
+			),
+			oauth2Consent: createAuthEndpoint(
+				"/oauth2/consent",
+				{
+					method: "POST",
+					body: z.object({
+						accept: z.boolean(),
+					}),
+					use: [sessionMiddleware],
+					metadata: {
+						openapi: {
+							description: "Handle OAuth2 consent",
+							responses: {
+								"200": {
+									description: "Consent processed successfully",
+									content: {
+										"application/json": {
+											schema: {
+												type: "object",
+												properties: {
+													redirect_uri: {
+														type: "string",
+														format: "uri",
+														description:
+															"The URI to redirect to, either with an authorization code or an error",
+													},
+												},
+												required: ["redirect_uri"],
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				async (ctx) => {
+					return consentEndpoint(ctx, opts);
+				},
+			),
+			oauth2Token: createAuthEndpoint(
+				"/oauth2/token",
+				{
+					method: "POST",
+					body: z.object({
+						grant_type: z.enum([
+							"authorization_code",
+							"client_credentials",
+							"refresh_token",
+						]),
+						client_id: z.string().optional(),
+						client_secret: z.string().optional(),
+						code: z.string().optional(),
+						code_verifier: z.string().optional(),
+						redirect_uri: z.string().optional(),
+						refresh_token: z.string().optional(),
+						resource: z.string().optional(),
+						scope: z.string().optional(),
+					}),
+					metadata: {
+						isAction: false,
+						openapi: {
+							description: "Obtain an OAuth2.1 access token",
+							requestBody: {
+								required: true,
+								content: {
+									"application/json": {
+										schema: {
+											type: "object",
+											properties: {
+												grant_type: {
+													type: "string",
+													enum: [
+														"authorization_code",
+														"client_credentials",
+														"refresh_token",
+													],
+													description: "OAuth2 grant type",
+												},
+												client_id: {
+													type: "string",
+													description: "OAuth2 client ID",
+												},
+												client_secret: {
+													type: "string",
+													description: "OAuth2 client secret",
+												},
+												code: {
+													type: "string",
+													description:
+														"Authorization code (for authorization_code grant)",
+												},
+												code_verifier: {
+													type: "string",
+													description:
+														"PKCE code verifier (for authorization_code grant)",
+												},
+												redirect_uri: {
+													type: "string",
+													format: "uri",
+													description:
+														"Redirect URI (for authorization_code grant)",
+												},
+												refresh_token: {
+													type: "string",
+													description:
+														"Refresh token (for refresh_token grant)",
+												},
+												resource: {
+													type: "string",
+													description:
+														"Requested token resource (ie audience) to obtain a JWT formatted access token",
+												},
+												scope: {
+													type: "string",
+													description:
+														"Requested scopes (for client_credentials grant)",
+												},
+											},
+											required: ["grant_type"],
+										},
+									},
+								},
+							},
+							responses: {
+								"200": {
+									description: "Access token response",
+									content: {
+										"application/json": {
+											schema: {
+												type: "object",
+												properties: {
+													access_token: {
+														type: "string",
+														description:
+															"The access token issued by the authorization server",
+													},
+													token_type: {
+														type: "string",
+														description: "The type of the token issued",
+														enum: ["Bearer"],
+													},
+													expires_in: {
+														type: "number",
+														description:
+															"Lifetime in seconds of the access token",
+													},
+													refresh_token: {
+														type: "string",
+														description: "Refresh token, if issued",
+													},
+													scope: {
+														type: "string",
+														description: "Scopes granted by the access token",
+													},
+													id_token: {
+														type: "string",
+														description: "ID Token (if OpenID Connect)",
+													},
+												},
+												required: ["access_token", "token_type", "expires_in"],
+											},
+										},
+									},
+								},
+								"400": {
+									description: "Invalid request or error response",
+									content: {
+										"application/json": {
+											schema: {
+												type: "object",
+												properties: {
+													error: { type: "string" },
+													error_description: { type: "string" },
+													error_uri: { type: "string" },
+												},
+												required: ["error"],
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				async (ctx) => {
+					return tokenEndpoint(ctx, opts);
+				},
+			),
+			oauth2Introspect: createAuthEndpoint(
+				"/oauth2/introspect",
+				{
+					method: "POST",
+					body: z.object({
+						client_id: z.string().optional(),
+						client_secret: z.string().optional(),
+						token: z.string(),
+						token_type_hint: z
+							.enum(["access_token", "refresh_token"])
+							.optional(),
+					}),
+					metadata: {
+						isAction: false,
+						openapi: {
+							description: "Introspect an OAuth2 access or refresh token",
+							requestBody: {
+								required: true,
+								content: {
+									"application/json": {
+										schema: {
+											type: "object",
+											properties: {
+												client_id: {
+													type: "string",
+													description: "OAuth2 client ID",
+												},
+												client_secret: {
+													type: "string",
+													description: "OAuth2 client secret",
+												},
+												token: {
+													type: "string",
+													description:
+														"The token to introspect (access or refresh token)",
+												},
+												token_type_hint: {
+													type: "string",
+													enum: ["access_token", "refresh_token"],
+													description:
+														"Hint about the type of the token submitted for introspection",
+												},
+											},
+											required: ["token"],
+										},
+									},
+								},
+							},
+							responses: {
+								"200": {
+									description: "Token introspection response",
+									content: {
+										"application/json": {
+											schema: {
+												type: "object",
+												properties: {
+													active: {
+														type: "boolean",
+														description: "Whether the token is active",
+													},
+													scope: {
+														type: "string",
+														description: "Scopes associated with the token",
+													},
+													client_id: {
+														type: "string",
+														description: "Client ID associated with the token",
+													},
+													username: {
+														type: "string",
+														description: "Username associated with the token",
+													},
+													token_type: {
+														type: "string",
+														description: "Type of the token",
+													},
+													exp: {
+														type: "number",
+														description:
+															"Expiration time of the token (seconds since epoch)",
+													},
+													iat: {
+														type: "number",
+														description: "Issued at time (seconds since epoch)",
+													},
+													nbf: {
+														type: "number",
+														description:
+															"Not before time (seconds since epoch)",
+													},
+													sub: {
+														type: "string",
+														description: "Subject of the token",
+													},
+													aud: {
+														type: "string",
+														description: "Audience of the token",
+													},
+													iss: {
+														type: "string",
+														description: "Issuer of the token",
+													},
+													jti: {
+														type: "string",
+														description: "JWT ID",
+													},
+												},
+												required: ["active"],
+											},
+										},
+									},
+								},
+								"400": {
+									description: "Invalid request or error response",
+									content: {
+										"application/json": {
+											schema: {
+												type: "object",
+												properties: {
+													error: { type: "string" },
+													error_description: { type: "string" },
+													error_uri: { type: "string" },
+												},
+												required: ["error"],
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				async (ctx) => {
+					return introspectEndpoint(ctx, opts);
+				},
+			),
+			oauth2IntrospectVerify: createAuthEndpoint(
+				"/oauth2/introspect/verify",
+				{
+					method: "POST",
+					body: z
+						.object({
+							token: z.string().optional(),
+							options: z.object().optional(),
+						})
+						.optional(),
+					metadata: {
+						SERVER_ONLY: true,
+					},
+				},
+				async (ctx) => {
+					return introspectVerifyEndpoint(
+						ctx,
+						opts,
+						ctx.body?.token,
+						ctx.body?.options,
+					);
+				},
+			),
+			oauth2Revoke: createAuthEndpoint(
+				"/oauth2/revoke",
+				{
+					method: "POST",
+					body: z.object({
+						client_id: z.string().optional(),
+						client_secret: z.string().optional(),
+						token: z.string(),
+						token_type_hint: z
+							.enum(["access_token", "refresh_token"])
+							.optional(),
+					}),
+					metadata: {
+						isAction: false,
+						openapi: {
+							description: "Revoke an OAuth2 access or refresh token",
+							requestBody: {
+								required: true,
+								content: {
+									"application/json": {
+										schema: {
+											type: "object",
+											properties: {
+												client_id: {
+													type: "string",
+													description: "OAuth2 client ID",
+												},
+												client_secret: {
+													type: "string",
+													description: "OAuth2 client secret",
+												},
+												token: {
+													type: "string",
+													description:
+														"The token to revoke (access or refresh token)",
+												},
+												token_type_hint: {
+													type: "string",
+													enum: ["access_token", "refresh_token"],
+													description:
+														"Hint about the type of the token submitted for revocation",
+												},
+											},
+											required: ["token"],
+										},
+									},
+								},
+							},
+							responses: {
+								"200": {
+									description:
+										"Token revoked successfully. The response body is empty.",
+									content: {
+										"application/json": {
+											schema: {
+												type: "object",
+												description: "Empty object on success",
+											},
+										},
+									},
+								},
+								"400": {
+									description: "Invalid request or error response",
+									content: {
+										"application/json": {
+											schema: {
+												type: "object",
+												properties: {
+													error: { type: "string" },
+													error_description: { type: "string" },
+													error_uri: { type: "string" },
+												},
+												required: ["error"],
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				async (ctx) => {
+					return revokeEndpoint(ctx, opts);
+				},
+			),
+			oauth2UserInfo: createAuthEndpoint(
+				"/oauth2/userinfo",
+				{
+					method: "GET",
+					metadata: {
+						isAction: false,
+						openapi: {
+							description:
+								"Get OpenID Connect user information (UserInfo endpoint)",
+							security: [
+								{ bearerAuth: [] },
+								{ OAuth2: ["openid", "profile", "email"] },
+							],
+							parameters: [
+								{
+									name: "Authorization",
+									in: "header",
+									required: false,
+									schema: { type: "string" },
+									description: "Bearer access token",
+								},
+							],
+							responses: {
+								"200": {
+									description: "User information retrieved successfully",
+									content: {
+										"application/json": {
+											schema: {
+												type: "object",
+												properties: {
+													sub: {
+														type: "string",
+														description: "Subject identifier (user ID)",
+													},
+													email: {
+														type: "string",
+														format: "email",
+														nullable: true,
+														description:
+															"User's email address, included if 'email' scope is granted",
+													},
+													name: {
+														type: "string",
+														nullable: true,
+														description:
+															"User's full name, included if 'profile' scope is granted",
+													},
+													picture: {
+														type: "string",
+														format: "uri",
+														nullable: true,
+														description:
+															"User's profile picture URL, included if 'profile' scope is granted",
+													},
+													given_name: {
+														type: "string",
+														nullable: true,
+														description:
+															"User's given name, included if 'profile' scope is granted",
+													},
+													family_name: {
+														type: "string",
+														nullable: true,
+														description:
+															"User's family name, included if 'profile' scope is granted",
+													},
+													email_verified: {
+														type: "boolean",
+														nullable: true,
+														description:
+															"Whether the email is verified, included if 'email' scope is granted",
+													},
+												},
+												required: ["sub"],
+											},
+										},
+									},
+								},
+								"401": {
+									description: "Unauthorized - invalid or missing access token",
+									content: {
+										"application/json": {
+											schema: {
+												type: "object",
+												properties: {
+													error: { type: "string" },
+													error_description: { type: "string" },
+												},
+												required: ["error"],
+											},
+										},
+									},
+								},
+								"403": {
+									description: "Forbidden - insufficient scope",
+									content: {
+										"application/json": {
+											schema: {
+												type: "object",
+												properties: {
+													error: { type: "string" },
+													error_description: { type: "string" },
+												},
+												required: ["error"],
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				async (ctx) => {
+					return userInfoEndpoint(ctx, opts);
+				},
+			),
+			registerOAuthClient: createAuthEndpoint(
+				"/oauth2/server/register",
+				{
+					method: "POST",
+					body: z.object({
+						redirect_uris: z.array(z.string()),
+						scope: z.string().optional(),
+						client_name: z.string().optional(),
+						client_uri: z.string().optional(),
+						logo_uri: z.string().optional(),
+						contacts: z.array(z.string()).optional(),
+						tos_uri: z.string().optional(),
+						policy_uri: z.string().optional(),
+						software_id: z.string().optional(),
+						software_version: z.string().optional(),
+						software_statement: z.string().optional(),
+						token_endpoint_auth_method: z
+							.enum(["none", "client_secret_basic", "client_secret_post"])
+							.default("client_secret_basic")
+							.optional(),
+						grant_types: z
+							.array(
+								z.enum([
+									"authorization_code",
+									"client_credentials",
+									"refresh_token",
+								]),
+							)
+							.default(["authorization_code"])
+							.optional(),
+						response_types: z
+							.array(z.enum(["code"]))
+							.default(["code"])
+							.optional(),
+						type: z.enum(["web", "native", "user-agent-based"]).optional(),
+						// SERVER_ONLY applicable fields
+						skip_consent: z.boolean().optional(),
+						metadata: z.object().optional(),
+					}),
+					metadata: {
+						SERVER_ONLY: true,
+						openapi: {
+							description: "Register an OAuth2 application",
+							responses: {
+								"200": {
+									description: "OAuth2 application registered successfully",
+									content: {
+										"application/json": {
+											schema: {
+												/** @returns {OauthClient} */
+												type: "object",
+												properties: {
+													client_id: {
+														type: "string",
+														description: "Unique identifier for the client",
+													},
+													client_secret: {
+														type: "string",
+														description: "Secret key for the client",
+													},
+													client_secret_expires_at: {
+														type: "number",
+														description:
+															"Time the client secret will expire. If 0, the client secret will never expire.",
+													},
+													scope: {
+														type: "string",
+														description:
+															"Space-separated scopes allowed by the client",
+													},
+													user_id: {
+														type: "string",
+														description:
+															"ID of the user who registered the client, null if registered anonymously",
+													},
+													client_id_issued_at: {
+														type: "number",
+														description: "Creation timestamp of this client",
+													},
+													client_name: {
+														type: "string",
+														description: "Name of the OAuth2 application",
+													},
+													client_uri: {
+														type: "string",
+														description: "Name of the OAuth2 application",
+													},
+													logo_uri: {
+														type: "string",
+														description: "Icon URL for the application",
+													},
+													contacts: {
+														type: "array",
+														items: {
+															type: "string",
+														},
+														description:
+															"List representing ways to contact people responsible for this client, typically email addresses",
+													},
+													tos_uri: {
+														type: "string",
+														description: "Client's terms of service uri",
+													},
+													policy_uri: {
+														type: "string",
+														description: "Client's policy uri",
+													},
+													software_id: {
+														type: "string",
+														description:
+															"Unique identifier assigned by the developer to help in the dynamic registration process",
+													},
+													software_version: {
+														type: "string",
+														description:
+															"Version identifier for the software_id",
+													},
+													software_statement: {
+														type: "string",
+														description:
+															"JWT containing metadata values about the client software as claims",
+													},
+													redirect_uris: {
+														type: "array",
+														items: {
+															type: "string",
+															format: "uri",
+														},
+														description: "List of allowed redirect uris",
+													},
+													token_endpoint_auth_method: {
+														type: "string",
+														description:
+															"Requested authentication method for the token endpoint",
+														enum: [
+															"none",
+															"client_secret_basic",
+															"client_secret_post",
+														],
+													},
+													grant_types: {
+														type: "array",
+														items: {
+															type: "string",
+															enum: [
+																"authorization_code",
+																"client_credentials",
+																"refresh_token",
+															],
+														},
+														description:
+															"Requested authentication method for the token endpoint",
+													},
+													response_types: {
+														type: "array",
+														items: {
+															type: "string",
+															enum: ["code"],
+														},
+														description:
+															"Requested authentication method for the token endpoint",
+													},
+													public: {
+														type: "boolean",
+														description:
+															"Whether the client is public as determined by the type",
+													},
+													type: {
+														type: "string",
+														description: "Type of the client",
+														enum: ["web", "native", "user-agent-based"],
+													},
+													disabled: {
+														type: "boolean",
+														description: "Whether the client is disabled",
+													},
+													metadata: {
+														type: "object",
+														additionalProperties: true,
+														nullable: true,
+														description:
+															"Additional metadata for the application",
+													},
+												},
+												required: ["client_id"],
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				async (ctx) => {
+					return registerOAuthClient(ctx, opts);
+				},
+			),
+			dynamicRegisterOAuthClient: createAuthEndpoint(
+				"/oauth2/register",
+				{
+					method: "POST",
+					body: z.object({
+						redirect_uris: z.array(z.string()),
+						scope: z.string().optional(),
+						client_name: z.string().optional(),
+						client_uri: z.string().optional(),
+						logo_uri: z.string().optional(),
+						contacts: z.array(z.string()).optional(),
+						tos_uri: z.string().optional(),
+						policy_uri: z.string().optional(),
+						software_id: z.string().optional(),
+						software_version: z.string().optional(),
+						software_statement: z.string().optional(),
+						token_endpoint_auth_method: z
+							.enum(["none", "client_secret_basic", "client_secret_post"])
+							.default("client_secret_basic")
+							.optional(),
+						grant_types: z
+							.array(
+								z.enum([
+									"authorization_code",
+									"client_credentials",
+									"refresh_token",
+								]),
+							)
+							.default(["authorization_code"])
+							.optional(),
+						response_types: z
+							.array(z.enum(["code"]))
+							.default(["code"])
+							.optional(),
+						type: z.enum(["web", "native", "user-agent-based"]).optional(),
+					}),
+					metadata: {
+						openapi: {
+							description: "Register an OAuth2 application",
+							responses: {
+								"200": {
+									description: "OAuth2 application registered successfully",
+									content: {
+										"application/json": {
+											schema: {
+												/** @returns {OauthClient} */
+												type: "object",
+												properties: {
+													client_id: {
+														type: "string",
+														description: "Unique identifier for the client",
+													},
+													client_secret: {
+														type: "string",
+														description: "Secret key for the client",
+													},
+													client_secret_expires_at: {
+														type: "number",
+														description:
+															"Time the client secret will expire. If 0, the client secret will never expire.",
+													},
+													scope: {
+														type: "string",
+														description:
+															"Space-separated scopes allowed by the client",
+													},
+													user_id: {
+														type: "string",
+														description:
+															"ID of the user who registered the client, null if registered anonymously",
+													},
+													client_id_issued_at: {
+														type: "number",
+														description: "Creation timestamp of this client",
+													},
+													client_name: {
+														type: "string",
+														description: "Name of the OAuth2 application",
+													},
+													client_uri: {
+														type: "string",
+														description: "Name of the OAuth2 application",
+													},
+													logo_uri: {
+														type: "string",
+														description: "Icon URL for the application",
+													},
+													contacts: {
+														type: "array",
+														items: {
+															type: "string",
+														},
+														description:
+															"List representing ways to contact people responsible for this client, typically email addresses",
+													},
+													tos_uri: {
+														type: "string",
+														description: "Client's terms of service uri",
+													},
+													policy_uri: {
+														type: "string",
+														description: "Client's policy uri",
+													},
+													software_id: {
+														type: "string",
+														description:
+															"Unique identifier assigned by the developer to help in the dynamic registration process",
+													},
+													software_version: {
+														type: "string",
+														description:
+															"Version identifier for the software_id",
+													},
+													software_statement: {
+														type: "string",
+														description:
+															"JWT containing metadata values about the client software as claims",
+													},
+													redirect_uris: {
+														type: "array",
+														items: {
+															type: "string",
+															format: "uri",
+														},
+														description: "List of allowed redirect uris",
+													},
+													token_endpoint_auth_method: {
+														type: "string",
+														description:
+															"Requested authentication method for the token endpoint",
+														enum: [
+															"none",
+															"client_secret_basic",
+															"client_secret_post",
+														],
+													},
+													grant_types: {
+														type: "array",
+														items: {
+															type: "string",
+															enum: [
+																"authorization_code",
+																"client_credentials",
+																"refresh_token",
+															],
+														},
+														description:
+															"Requested authentication method for the token endpoint",
+													},
+													response_types: {
+														type: "array",
+														items: {
+															type: "string",
+															enum: ["code"],
+														},
+														description:
+															"Requested authentication method for the token endpoint",
+													},
+													public: {
+														type: "boolean",
+														description:
+															"Whether the client is public as determined by the type",
+													},
+													type: {
+														type: "string",
+														description: "Type of the client",
+														enum: ["web", "native", "user-agent-based"],
+													},
+													disabled: {
+														type: "boolean",
+														description: "Whether the client is disabled",
+													},
+												},
+												required: ["client_id"],
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				async (ctx) => {
+					return dynamicRegisterEndpoint(ctx, opts);
+				},
+			),
+		},
+		schema: mergeSchema(schema, opts?.schema),
+	} satisfies BetterAuthPlugin;
+};

--- a/packages/better-auth/src/plugins/oauth-provider/oauth.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/oauth.ts
@@ -26,7 +26,6 @@ import { revokeEndpoint } from "./revoke";
 import { BetterAuthError } from "@better-auth/core/error";
 import { logger } from "@better-auth/core/env";
 import type { ResourceServerMetadata } from "../../oauth-2.1/types";
-import { introspectVerifyEndpoint } from "./verify";
 import * as oauthClientEndpoints from "./oauthClient";
 
 /**
@@ -769,29 +768,6 @@ export const oauthProvider = (options: OAuthOptions) => {
 				},
 				async (ctx) => {
 					return introspectEndpoint(ctx, opts);
-				},
-			),
-			oauth2IntrospectVerify: createAuthEndpoint(
-				"/oauth2/introspect/verify",
-				{
-					method: "POST",
-					body: z
-						.object({
-							token: z.string().optional(),
-							options: z.object().optional(),
-						})
-						.optional(),
-					metadata: {
-						SERVER_ONLY: true,
-					},
-				},
-				async (ctx) => {
-					return introspectVerifyEndpoint(
-						ctx,
-						opts,
-						ctx.body?.token,
-						ctx.body?.options,
-					);
 				},
 			),
 			oauth2Revoke: createAuthEndpoint(

--- a/packages/better-auth/src/plugins/oauth-provider/oauthClient/endpoints.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/oauthClient/endpoints.ts
@@ -1,0 +1,168 @@
+import type { GenericEndpointContext } from "packages/core/dist";
+import type { OAuthOptions } from "../types";
+import { APIError } from "../../../api";
+import { getClient, storeClientSecret } from "../utils";
+import {
+	checkOAuthClient,
+	databaseToSchema,
+	oauthToSchema,
+	schemaToDatabase,
+	schemaToOAuth,
+} from "../register";
+import type { DatabaseClient } from "../register";
+import type { OAuthClient } from "../../../oauth-2.1/types";
+import { generateRandomString } from "../../../crypto";
+
+export async function getClientEndpoint(
+	ctx: GenericEndpointContext & { params: { id: string } },
+	opts: OAuthOptions,
+) {
+	const client = await getClient(ctx, opts, ctx.params.id);
+	if (!client) {
+		throw new APIError("NOT_FOUND", {
+			error_description: "client not found",
+			error: "not_found",
+		});
+	}
+	// Never return @internal client_secret
+	if (client?.clientSecret) {
+		client.clientSecret = undefined;
+	}
+	return schemaToOAuth(client, false);
+}
+
+export async function deleteClientEndpoint(
+	ctx: GenericEndpointContext & { params: { id: string } },
+	opts: OAuthOptions,
+) {
+	const client = await getClient(ctx, opts, ctx.params.id);
+	if (!client) {
+		throw new APIError("NOT_FOUND", {
+			error_description: "client not found",
+			error: "not_found",
+		});
+	}
+
+	await ctx.context.adapter.delete({
+		model: opts.schema?.oauthClient?.modelName ?? "oauthClient",
+		where: [
+			{
+				field: "id",
+				value: ctx.params.id,
+			},
+		],
+	});
+}
+
+export async function updateClientEndpoint(
+	ctx: GenericEndpointContext & { params: { id: string } },
+	opts: OAuthOptions,
+) {
+	const trustedClient = opts.trustedClients?.find(
+		(client) => client.clientId === ctx.params.id,
+	);
+	if (trustedClient) {
+		throw new APIError("INTERNAL_SERVER_ERROR", {
+			error_description: "trusted clients must be updated manually",
+			error: "invalid_client",
+		});
+	}
+
+	const client = await getClient(ctx, opts, ctx.params.id);
+	if (!client) {
+		throw new APIError("NOT_FOUND", {
+			error_description: "client not found",
+			error: "not_found",
+		});
+	}
+
+	const updates = ctx.body as OAuthClient;
+	await checkOAuthClient(
+		{
+			...schemaToOAuth(client),
+			...updates,
+		},
+		opts,
+	);
+
+	const updatedClient = await ctx.context.adapter
+		.update<DatabaseClient>({
+			model: opts.schema?.oauthClient?.modelName ?? "oauthClient",
+			where: [
+				{
+					field: "id",
+					value: ctx.params.id,
+				},
+			],
+			update: schemaToDatabase(oauthToSchema(updates)),
+		})
+		.then((res) => {
+			return databaseToSchema(res as DatabaseClient);
+		});
+
+	// Never return @internal client_secret
+	if (updatedClient?.clientSecret) {
+		updatedClient.clientSecret = undefined;
+	}
+	return schemaToOAuth(updatedClient, false);
+}
+
+export async function rotateClientSecretEndpoint(
+	ctx: GenericEndpointContext & { params: { id: string } },
+	opts: OAuthOptions,
+) {
+	const trustedClient = opts.trustedClients?.find(
+		(client) => client.clientId === ctx.params.id,
+	);
+	if (trustedClient) {
+		throw new APIError("INTERNAL_SERVER_ERROR", {
+			error_description: "trusted clients must be updated manually",
+			error: "invalid_client",
+		});
+	}
+
+	const client = await getClient(ctx, opts, ctx.params.id);
+	if (!client) {
+		throw new APIError("NOT_FOUND", {
+			error_description: "client not found",
+			error: "not_found",
+		});
+	}
+
+	if (client.public || !client.clientSecret) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "public clients cannot be updated",
+			error: "invalid_client",
+		});
+	}
+
+	const clientSecret =
+		opts.generateClientSecret?.() || generateRandomString(32, "a-z", "A-Z");
+	const storedClientSecret = clientSecret
+		? await storeClientSecret(ctx, opts, clientSecret)
+		: undefined;
+
+	const updatedClient = await ctx.context.adapter
+		.update<DatabaseClient>({
+			model: opts.schema?.oauthClient?.modelName ?? "oauthClient",
+			where: [
+				{
+					field: "id",
+					value: ctx.params.id,
+				},
+			],
+			update: {
+				client_secret: storedClientSecret,
+			},
+		})
+		.then((res) => {
+			return databaseToSchema(res as DatabaseClient);
+		});
+	return schemaToOAuth(
+		{
+			...updatedClient,
+			clientSecret: (opts.clientSecretPrefix ?? "") + clientSecret,
+		},
+		false,
+	);
+}

--- a/packages/better-auth/src/plugins/oauth-provider/oauthClient/index.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/oauthClient/index.ts
@@ -1,0 +1,306 @@
+import { z } from "zod";
+import type { OAuthOptions } from "../types";
+import { createAuthEndpoint } from "../../../api";
+import {
+	getClientEndpoint,
+	updateClientEndpoint,
+	rotateClientSecretEndpoint,
+	deleteClientEndpoint,
+} from "./endpoints";
+import { createOAuthClientEndpoint } from "../register";
+
+export const createOAuthClient = (opts: OAuthOptions) =>
+	createAuthEndpoint(
+		"/oauth2/client",
+		{
+			method: "POST",
+			body: z.object({
+				redirect_uris: z.array(z.string()),
+				scope: z.string().optional(),
+				client_name: z.string().optional(),
+				client_uri: z.string().optional(),
+				logo_uri: z.string().optional(),
+				contacts: z.array(z.string()).optional(),
+				tos_uri: z.string().optional(),
+				policy_uri: z.string().optional(),
+				software_id: z.string().optional(),
+				software_version: z.string().optional(),
+				software_statement: z.string().optional(),
+				token_endpoint_auth_method: z
+					.enum(["none", "client_secret_basic", "client_secret_post"])
+					.default("client_secret_basic")
+					.optional(),
+				grant_types: z
+					.array(
+						z.enum([
+							"authorization_code",
+							"client_credentials",
+							"refresh_token",
+						]),
+					)
+					.default(["authorization_code"])
+					.optional(),
+				response_types: z
+					.array(z.enum(["code"]))
+					.default(["code"])
+					.optional(),
+				type: z.enum(["web", "native", "user-agent-based"]).optional(),
+				// SERVER_ONLY applicable fields
+				skip_consent: z.boolean().optional(),
+				metadata: z.object().optional(),
+			}),
+			metadata: {
+				SERVER_ONLY: true,
+				openapi: {
+					description: "Register an OAuth2 application",
+					responses: {
+						"200": {
+							description: "OAuth2 application registered successfully",
+							content: {
+								"application/json": {
+									schema: {
+										/** @returns {OauthClient} */
+										type: "object",
+										properties: {
+											client_id: {
+												type: "string",
+												description: "Unique identifier for the client",
+											},
+											client_secret: {
+												type: "string",
+												description: "Secret key for the client",
+											},
+											client_secret_expires_at: {
+												type: "number",
+												description:
+													"Time the client secret will expire. If 0, the client secret will never expire.",
+											},
+											scope: {
+												type: "string",
+												description:
+													"Space-separated scopes allowed by the client",
+											},
+											user_id: {
+												type: "string",
+												description:
+													"ID of the user who registered the client, null if registered anonymously",
+											},
+											client_id_issued_at: {
+												type: "number",
+												description: "Creation timestamp of this client",
+											},
+											client_name: {
+												type: "string",
+												description: "Name of the OAuth2 application",
+											},
+											client_uri: {
+												type: "string",
+												description: "Name of the OAuth2 application",
+											},
+											logo_uri: {
+												type: "string",
+												description: "Icon URL for the application",
+											},
+											contacts: {
+												type: "array",
+												items: {
+													type: "string",
+												},
+												description:
+													"List representing ways to contact people responsible for this client, typically email addresses",
+											},
+											tos_uri: {
+												type: "string",
+												description: "Client's terms of service uri",
+											},
+											policy_uri: {
+												type: "string",
+												description: "Client's policy uri",
+											},
+											software_id: {
+												type: "string",
+												description:
+													"Unique identifier assigned by the developer to help in the dynamic registration process",
+											},
+											software_version: {
+												type: "string",
+												description: "Version identifier for the software_id",
+											},
+											software_statement: {
+												type: "string",
+												description:
+													"JWT containing metadata values about the client software as claims",
+											},
+											redirect_uris: {
+												type: "array",
+												items: {
+													type: "string",
+													format: "uri",
+												},
+												description: "List of allowed redirect uris",
+											},
+											token_endpoint_auth_method: {
+												type: "string",
+												description:
+													"Requested authentication method for the token endpoint",
+												enum: [
+													"none",
+													"client_secret_basic",
+													"client_secret_post",
+												],
+											},
+											grant_types: {
+												type: "array",
+												items: {
+													type: "string",
+													enum: [
+														"authorization_code",
+														"client_credentials",
+														"refresh_token",
+													],
+												},
+												description:
+													"Requested authentication method for the token endpoint",
+											},
+											response_types: {
+												type: "array",
+												items: {
+													type: "string",
+													enum: ["code"],
+												},
+												description:
+													"Requested authentication method for the token endpoint",
+											},
+											public: {
+												type: "boolean",
+												description:
+													"Whether the client is public as determined by the type",
+											},
+											type: {
+												type: "string",
+												description: "Type of the client",
+												enum: ["web", "native", "user-agent-based"],
+											},
+											disabled: {
+												type: "boolean",
+												description: "Whether the client is disabled",
+											},
+											metadata: {
+												type: "object",
+												additionalProperties: true,
+												nullable: true,
+												description: "Additional metadata for the application",
+											},
+										},
+										required: ["client_id"],
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		async (ctx) => {
+			return createOAuthClientEndpoint(ctx, opts);
+		},
+	);
+
+export const getOAuthClient = (opts: OAuthOptions) =>
+	createAuthEndpoint(
+		"/oauth2/client/:id",
+		{
+			method: "GET",
+			metadata: {
+				SERVER_ONLY: true,
+				openapi: {
+					description: "Get OAuth2 formatted client details",
+				},
+			},
+		},
+		async (ctx) => {
+			return getClientEndpoint(ctx, opts);
+		},
+	);
+
+export const updateOAuthClient = (opts: OAuthOptions) =>
+	createAuthEndpoint(
+		"/oauth2/client/:id",
+		{
+			method: "PATCH",
+			body: z.object({
+				redirect_uris: z.array(z.string()).optional(),
+				scope: z.string().optional(),
+				client_name: z.string().optional(),
+				client_uri: z.string().optional(),
+				logo_uri: z.string().optional(),
+				contacts: z.array(z.string()).optional(),
+				tos_uri: z.string().optional(),
+				policy_uri: z.string().optional(),
+				software_id: z.string().optional(),
+				software_version: z.string().optional(),
+				software_statement: z.string().optional(),
+				// NOTE: token_endpoint_auth_method is currently immutable since it changes isPublic definition
+				grant_types: z
+					.array(
+						z.enum([
+							"authorization_code",
+							"client_credentials",
+							"refresh_token",
+						]),
+					)
+					.default(["authorization_code"])
+					.optional(),
+				response_types: z
+					.array(z.enum(["code"]))
+					.default(["code"])
+					.optional(),
+				type: z.enum(["web", "native", "user-agent-based"]).optional(),
+				skip_consent: z.boolean().optional(),
+				metadata: z.object().optional(),
+			}),
+			metadata: {
+				SERVER_ONLY: true,
+				openapi: {
+					description: "Updates OAuth2 formatted client details.",
+				},
+			},
+		},
+		async (ctx) => {
+			return updateClientEndpoint(ctx, opts);
+		},
+	);
+
+export const rotateClientSecret = (opts: OAuthOptions) =>
+	createAuthEndpoint(
+		"/oauth2/client/:id/rotate-secret",
+		{
+			method: "POST",
+			metadata: {
+				SERVER_ONLY: true,
+				openapi: {
+					description: "Rotates a confidential client's secret",
+				},
+			},
+		},
+		async (ctx) => {
+			return rotateClientSecretEndpoint(ctx, opts);
+		},
+	);
+
+export const deleteOAuthClient = (opts: OAuthOptions) =>
+	createAuthEndpoint(
+		"/oauth2/client/:id",
+		{
+			method: "DELETE",
+			metadata: {
+				SERVER_ONLY: true,
+				openapi: {
+					description: "Deletes an oauth client",
+				},
+			},
+		},
+		async (ctx) => {
+			return deleteClientEndpoint(ctx, opts);
+		},
+	);

--- a/packages/better-auth/src/plugins/oauth-provider/register.test.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/register.test.ts
@@ -76,7 +76,7 @@ describe("oauth register", async () => {
 	});
 
 	it("should register private client with minimum requirements via server", async () => {
-		const response = await auth.api.registerOAuthClient({
+		const response = await auth.api.createOAuthClient({
 			headers,
 			body: {
 				redirect_uris: [redirectUri],
@@ -120,7 +120,7 @@ describe("oauth register", async () => {
 	it.each(["native", "user-agent-based"] as OAuthClient["type"][])(
 		"should register public '%s' client with minimum requirements via server",
 		async (type) => {
-			const response = await auth.api.registerOAuthClient({
+			const response = await auth.api.createOAuthClient({
 				headers,
 				body: {
 					token_endpoint_auth_method: "none",

--- a/packages/better-auth/src/plugins/oauth-provider/register.test.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/register.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it } from "vitest";
+import { oauthProvider } from "./oauth";
+import type { OAuthClient } from "../../oauth-2.1/types";
+import { createAuthClient } from "../../client";
+import { getTestInstance } from "../../test-utils/test-instance";
+import { jwt } from "../jwt";
+import { oauthProviderClient } from "./client";
+
+describe("oauth register", async () => {
+	const baseUrl = "http://localhost:3000";
+	const rpBaseUrl = "http://localhost:5000";
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL: baseUrl,
+		plugins: [
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				allowDynamicClientRegistration: true,
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+				scopes: [
+					"openid",
+					"profile",
+					"email",
+					"offline_access",
+					"create:test",
+					"delete:test",
+				],
+			}),
+			jwt(),
+		],
+	});
+	const { headers } = await signInWithTestUser();
+	const serverClient = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: baseUrl,
+		fetchOptions: {
+			customFetchImpl,
+			headers,
+		},
+	});
+
+	const providerId = "test";
+	const redirectUri = `${rpBaseUrl}/api/auth/oauth2/callback/${providerId}`;
+
+	it("should fail without body", async () => {
+		const response = await serverClient.$fetch("/oauth2/register", {
+			method: "POST",
+		});
+		expect(response.error?.status).toBe(400);
+	});
+
+	it("should fail without authentication", async () => {
+		const unauthenticatedClient = createAuthClient({
+			plugins: [oauthProviderClient()],
+			baseURL: baseUrl,
+			fetchOptions: {
+				customFetchImpl,
+			},
+		});
+		const response = await unauthenticatedClient.oauth2.register({
+			redirect_uris: [redirectUri],
+		});
+		expect(response.error?.status).toBe(401);
+	});
+
+	it("should register private client with minimum requirements", async () => {
+		const response = await serverClient.oauth2.register({
+			redirect_uris: [redirectUri],
+		});
+		expect(response.data?.client_id).toBeDefined();
+		expect(response.data?.user_id).toBeDefined();
+		expect(response.data?.client_secret).toBeDefined();
+	});
+
+	it("should register private client with minimum requirements via server", async () => {
+		const response = await auth.api.registerOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [redirectUri],
+			},
+		});
+		expect(response?.client_id).toBeDefined();
+		expect(response?.user_id).toBeDefined();
+		expect(response?.client_secret).toBeDefined();
+	});
+
+	it("should fail authorization_code without response type code", async () => {
+		const response = await serverClient.oauth2.register({
+			// @ts-expect-error testing with a different response type even though unsupported
+			response_types: ["token"],
+			redirect_uris: [redirectUri],
+		});
+		expect(response.error?.status).toBe(400);
+	});
+
+	it("should fail type check for public client request", async () => {
+		const response = await serverClient.oauth2.register({
+			token_endpoint_auth_method: "none",
+			type: "web",
+			redirect_uris: [redirectUri],
+		});
+		expect(response.error?.status).toBe(400);
+	});
+
+	it.each(["native", "user-agent-based"] as OAuthClient["type"][])(
+		"should fail with type '%s' check for confidential client request",
+		async (type) => {
+			const response = await serverClient.oauth2.register({
+				token_endpoint_auth_method: "client_secret_post",
+				type,
+				redirect_uris: [redirectUri],
+			});
+			expect(response.error?.status).toBe(400);
+		},
+	);
+
+	it.each(["native", "user-agent-based"] as OAuthClient["type"][])(
+		"should register public '%s' client with minimum requirements via server",
+		async (type) => {
+			const response = await auth.api.registerOAuthClient({
+				headers,
+				body: {
+					token_endpoint_auth_method: "none",
+					redirect_uris: [redirectUri],
+				},
+			});
+			expect(response?.client_id).toBeDefined();
+			expect(response?.user_id).toBeDefined();
+			expect(response?.client_secret).toBeUndefined();
+		},
+	);
+
+	it("should register confidential client and check that certain fields are overwritten", async () => {
+		const applicationRequest: OAuthClient = {
+			client_id: "bad-actor",
+			client_secret: "bad-actor",
+			client_secret_expires_at: 0,
+			scope: "create:test delete:test",
+			//---- Recommended client data ----//
+			user_id: "bad-actor",
+			client_id_issued_at: Math.round(Date.now() / 1000),
+			//---- UI Metadata ----//
+			client_name: "accept name",
+			client_uri: "https://example.com/ok",
+			logo_uri: "https://example.com/logo.png",
+			contacts: ["test@example.com"],
+			tos_uri: "https://example.com/terms",
+			policy_uri: "https://example.com/policy",
+			//---- Jwks (only one can be used) ----//
+			// jwks: [],
+			// jwks_uri: "https://example.com/.well-known/jwks.json",
+			//---- User Software Identifiers ----//
+			software_id: "custom-software-id",
+			software_version: "custom-v1",
+			software_statement: "custom software statement",
+			//---- Authentication Metadata ----//
+			redirect_uris: ["https://example.com/callback"],
+			token_endpoint_auth_method: "client_secret_post",
+			grant_types: [
+				"authorization_code",
+				"client_credentials",
+				"refresh_token",
+			],
+			response_types: ["code"],
+			//---- RFC6749 Spec ----//
+			public: true, // test never set on this (based off of token_endpoint_auth_method)
+			type: "web",
+			//---- Not Part of RFC7591 Spec ----//
+			disabled: false,
+		};
+		const response = await serverClient.$fetch<OAuthClient>(
+			"/oauth2/register",
+			{
+				method: "POST",
+				body: applicationRequest,
+			},
+		);
+
+		expect(response.data?.client_id).toBeDefined();
+		expect(response.data?.client_id).not.toEqual(applicationRequest.client_id);
+		expect(response.data?.client_secret).toBeDefined();
+		expect(response.data?.client_secret).not.toEqual(
+			applicationRequest.client_secret,
+		);
+		expect(response.data?.client_secret_expires_at).toEqual(0);
+		expect(response.data?.scope).toBeUndefined();
+		expect(response.data?.scope).not.toEqual(applicationRequest.scope);
+
+		expect(response.data?.user_id).toBeDefined();
+		expect(response.data?.user_id).not.toEqual(applicationRequest.user_id);
+		expect(response.data?.client_id_issued_at).toBeDefined();
+
+		expect(response.data).toMatchObject({
+			client_name: applicationRequest.client_name,
+			client_uri: applicationRequest.client_uri,
+			logo_uri: applicationRequest.logo_uri,
+			contacts: applicationRequest.contacts,
+			tos_uri: applicationRequest.tos_uri,
+			policy_uri: applicationRequest.policy_uri,
+		});
+
+		expect(response.data?.jwks).toBeUndefined();
+		expect(response.data?.jwks_uri).toBeUndefined();
+
+		expect(response.data).toMatchObject({
+			software_id: applicationRequest.software_id,
+			software_version: applicationRequest.software_version,
+			software_statement: applicationRequest.software_statement,
+			redirect_uris: applicationRequest.redirect_uris,
+			token_endpoint_auth_method: applicationRequest.token_endpoint_auth_method,
+			grant_types: applicationRequest.grant_types,
+			response_types: applicationRequest.response_types,
+		});
+
+		expect(response.data?.public).toBeFalsy();
+
+		expect(response.data?.disabled).toBeFalsy();
+	});
+});
+
+describe("oauth register - unauthenticated", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const rpBaseUrl = "http://localhost:5000";
+	const { customFetchImpl } = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			jwt(),
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				allowDynamicClientRegistration: true,
+				allowUnauthenticatedClientRegistration: true,
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+		],
+	});
+	const unauthenticatedClient = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: {
+			customFetchImpl,
+		},
+	});
+
+	const providerId = "test";
+	const redirectUri = `${rpBaseUrl}/api/auth/oauth2/callback/${providerId}`;
+
+	it("should create public clients without authentication", async () => {
+		const response = await unauthenticatedClient.oauth2.register({
+			token_endpoint_auth_method: "none",
+			redirect_uris: [redirectUri],
+		});
+		expect(response.data?.client_id).toBeDefined();
+		expect(response.data?.user_id).toBeDefined();
+		expect(response.data?.client_secret).toBeUndefined();
+	});
+
+	it("should not create confidential clients without authentication", async () => {
+		const response = await unauthenticatedClient.oauth2.register({
+			redirect_uris: [redirectUri],
+		});
+		expect(response.error?.status).toBe(401);
+	});
+});

--- a/packages/better-auth/src/plugins/oauth-provider/register.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/register.ts
@@ -1,0 +1,418 @@
+import type { GenericEndpointContext } from "@better-auth/core";
+import type { SchemaClient, OAuthOptions } from "./types";
+import type { OAuthClient } from "../../oauth-2.1/types";
+import { APIError, getSessionFromCtx } from "../../api";
+import { generateRandomString } from "../../crypto";
+import { storeClientSecret } from "./utils";
+import { toExpJWT } from "../jwt/utils";
+
+export async function dynamicRegisterEndpoint(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions,
+) {
+	// Check if registration endpoint is enabled
+	if (!opts.allowDynamicClientRegistration) {
+		throw new APIError("FORBIDDEN", {
+			error: "access_denied",
+			error_description: "Client registration is disabled",
+		});
+	}
+
+	const session = await getSessionFromCtx(ctx);
+
+	// Check authorization
+	if (!(session || opts.allowUnauthenticatedClientRegistration)) {
+		throw new APIError("UNAUTHORIZED", {
+			error: "invalid_token",
+			error_description: "Authentication required for client registration",
+		});
+	}
+
+	return registerOAuthClient(ctx, opts);
+}
+
+export async function registerOAuthClient(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions,
+) {
+	const body = ctx.body as OAuthClient;
+	const session = await getSessionFromCtx(ctx);
+
+	// Determine whether registration request for public client
+	// https://datatracker.ietf.org/doc/html/rfc7591#section-2
+	const isPublic = body.token_endpoint_auth_method === "none";
+
+	// Check unauthenticated user is requesting a confidential client
+	if (!session && !isPublic) {
+		throw new APIError("UNAUTHORIZED", {
+			error: "invalid_request",
+			error_description:
+				"Authentication required for confidential client registration",
+		});
+	}
+
+	// Check value of type, if sent, matches isPublic
+	if (body.type) {
+		if (
+			isPublic &&
+			!(body.type === "native" || body.type === "user-agent-based")
+		) {
+			throw new APIError("BAD_REQUEST", {
+				error: "invalid_client_metadata",
+				error_description: `Type must be 'native' or 'user-agent-based' for public applications`,
+			});
+		} else if (!isPublic && !(body.type === "web")) {
+			throw new APIError("BAD_REQUEST", {
+				error: "invalid_client_metadata",
+				error_description: `Type must be 'web' for confidential applications`,
+			});
+		}
+	}
+
+	// Validate redirect URIs for redirect-based flows
+	if (
+		(!body.grant_types || body.grant_types.includes("authorization_code")) &&
+		(!body.redirect_uris || body.redirect_uris.length === 0)
+	) {
+		throw new APIError("BAD_REQUEST", {
+			error: "invalid_redirect_uri",
+			error_description:
+				"Redirect URIs are required for authorization_code and implicit grant types",
+		});
+	}
+
+	// Validate correlation between grant_types and response_types
+	const grantTypes = body.grant_types ?? ["authorization_code"];
+	const responseTypes = body.response_types ?? ["code"];
+	if (
+		grantTypes.includes("authorization_code") &&
+		!responseTypes.includes("code")
+	) {
+		throw new APIError("BAD_REQUEST", {
+			error: "invalid_client_metadata",
+			error_description:
+				"When 'authorization_code' grant type is used, 'code' response type must be included",
+		});
+	}
+
+	// Generate clientId and clientSecret based on its type
+	const clientId =
+		opts.generateClientId?.() || generateRandomString(32, "a-z", "A-Z");
+	const clientSecret = isPublic
+		? undefined
+		: opts.generateClientSecret?.() || generateRandomString(32, "a-z", "A-Z");
+	const storedClientSecret = clientSecret
+		? await storeClientSecret(ctx, opts, clientSecret)
+		: undefined;
+
+	// Check requested application scopes
+	const requestedScopes = (body?.scope as string | undefined)
+		?.split(" ")
+		.filter((v) => v.length);
+	const allowedScopes = opts.clientRegistrationAllowedScopes ?? opts.scopes;
+	if (allowedScopes) {
+		for (const requestedScope of requestedScopes ?? []) {
+			if (!allowedScopes?.includes(requestedScope)) {
+				throw new APIError("BAD_REQUEST", {
+					error: "invalid_scope",
+					error_description: `cannot request scope ${requestedScope}`,
+				});
+			}
+		}
+	}
+
+	// Create the client with the existing schema
+	const iat = Math.floor(Date.now() / 1000);
+	let schema = oauthToSchema(
+		{
+			scope: opts.clientRegistrationDefaultScopes?.join(" "),
+			...((body ?? {}) as Partial<OAuthClient>),
+			// Dynamic registration should not have disabled defined
+			disabled: undefined,
+			// Jwks unsupported
+			jwks: undefined,
+			jwks_uri: undefined,
+			// Required if client secret is issued
+			client_secret_expires_at: storedClientSecret
+				? opts?.clientRegistrationClientSecretExpiration
+					? toExpJWT(opts.clientRegistrationClientSecretExpiration, iat)
+					: 0
+				: undefined,
+			// Override
+			client_id: clientId,
+			client_secret: storedClientSecret,
+			client_id_issued_at: iat,
+			public: isPublic,
+			user_id: session?.session.userId,
+		},
+		true,
+	);
+	const client = await ctx.context.adapter
+		.create<DatabaseClient>({
+			model: opts.schema?.oauthClient?.modelName ?? "oauthClient",
+			data: schemaToDatabase(schema),
+		})
+		.then((res) => {
+			return databaseToSchema(res as DatabaseClient);
+		});
+	// Format the response according to RFC7591
+	return ctx.json(
+		schemaToOAuth(
+			{
+				...client,
+				clientSecret: clientSecret
+					? (opts.clientSecretPrefix ?? "") + clientSecret
+					: undefined,
+			},
+			true,
+		),
+		{
+			status: 201,
+			headers: {
+				"Cache-Control": "no-store",
+				Pragma: "no-cache",
+			},
+		},
+	);
+}
+
+/**
+ * Client values as stored on the database.
+ * TODO: Easily removable when native `string[]` is used
+ *
+ * @internal
+ */
+export interface DatabaseClient
+	extends Omit<
+		SchemaClient,
+		| "allowedScopes"
+		| "contacts"
+		| "redirectUris"
+		| "grantTypes"
+		| "responseTypes"
+	> {
+	allowedScopes?: string;
+	contacts?: string;
+	redirectUris?: string;
+	grantTypes?: string;
+	responseTypes?: string;
+}
+
+/**
+ * Converts values stored on the database to a typed schema client.
+ * TODO: Easily removable when native `string[]` is used
+ *
+ * @internal
+ */
+export function databaseToSchema(input: DatabaseClient): SchemaClient {
+	return {
+		...input,
+		allowedScopes: input.allowedScopes?.split(" "),
+		contacts: input.contacts?.split(","),
+		redirectUris: input.redirectUris?.split(","),
+		grantTypes: input.grantTypes?.split(",") as SchemaClient["grantTypes"],
+		responseTypes: input.responseTypes?.split(
+			",",
+		) as SchemaClient["responseTypes"],
+	};
+}
+
+/**
+ * Converts typed schema client to untyped database type.
+ * TODO: Easily removable when native `string[]` is used
+ *
+ * @internal
+ */
+export function schemaToDatabase(input: SchemaClient): DatabaseClient {
+	return {
+		...input,
+		allowedScopes: input.allowedScopes?.join(" "),
+		contacts: input.contacts?.join(","),
+		redirectUris: input.redirectUris?.join(","),
+		grantTypes: input.grantTypes?.join(","),
+		responseTypes: input.responseTypes?.join(","),
+	};
+}
+
+/**
+ * Converts an OAuth 2.0 Dynamic Client Schema to a Database Schema
+ *
+ * @param input
+ * @param cleaned - determines if the `rest` is converted into metadata
+ * @returns
+ */
+export function oauthToSchema(
+	input: OAuthClient,
+	cleaned = true,
+): SchemaClient {
+	const {
+		// Important Fields
+		client_id: clientId,
+		client_secret: clientSecret,
+		client_secret_expires_at: _expiresAt,
+		scope: _scope,
+		// Recommended client data
+		user_id: userId,
+		client_id_issued_at: _createdAt,
+		// UI Metadata
+		client_name: name,
+		client_uri: uri,
+		logo_uri: icon,
+		contacts,
+		tos_uri: tos,
+		policy_uri: policy,
+		// Jwks (only one can be used)
+		jwks,
+		jwks_uri: jwksUri,
+		// User Software Identifiers
+		software_id: softwareId,
+		software_version: softwareVersion,
+		software_statement: softwareStatement,
+		// Authentication Metadata
+		redirect_uris: redirectUris,
+		token_endpoint_auth_method: tokenEndpointAuthMethod,
+		grant_types: grantTypes,
+		response_types: responseTypes,
+		// RFC6749 Spec
+		public: _public,
+		type,
+		// Not Part of RFC7591 Spec
+		disabled,
+		skip_consent: skipConsent,
+		// All other metadata
+		...rest
+	} = input;
+
+	// Type conversions
+	const expiresAt = _expiresAt ? new Date(_expiresAt * 1000) : undefined;
+	const createdAt = _createdAt ? new Date(_createdAt * 1000) : undefined;
+	const allowedScopes = _scope?.split(" ");
+
+	return {
+		// Important Fields
+		clientId,
+		clientSecret,
+		disabled,
+		allowedScopes,
+		// Recommended client data
+		userId,
+		createdAt,
+		expiresAt,
+		// UI Metadata
+		name,
+		uri,
+		icon,
+		contacts,
+		tos,
+		policy,
+		// User Software Identifiers
+		softwareId,
+		softwareVersion,
+		softwareStatement,
+		// Authentication Metadata
+		redirectUris,
+		tokenEndpointAuthMethod,
+		grantTypes,
+		responseTypes,
+		// RFC6749 Spec
+		public: _public,
+		type,
+		// All other metadata
+		skipConsent,
+		metadata: cleaned ? undefined : JSON.stringify(rest),
+	};
+}
+
+/**
+ * Converts a Database Schema to an OAuth 2.0 Dynamic Client Schema
+ * @param input
+ * @param cleaned - determines if the output has only Oauth 2.0 compatible data
+ * @returns
+ */
+export function schemaToOAuth(
+	input: SchemaClient,
+	cleaned = true,
+): OAuthClient {
+	const {
+		// Important Fields
+		clientId,
+		clientSecret,
+		disabled,
+		allowedScopes,
+		// Recommended client data
+		userId,
+		createdAt,
+		updatedAt,
+		expiresAt,
+		// UI Metadata
+		name,
+		uri,
+		icon,
+		contacts,
+		tos,
+		policy,
+		// User Software Identifiers
+		softwareId,
+		softwareVersion,
+		softwareStatement,
+		// Authentication Metadata
+		redirectUris,
+		tokenEndpointAuthMethod,
+		grantTypes,
+		responseTypes,
+		// RFC6749 Spec
+		public: _public,
+		type,
+		// All other metadata
+		skipConsent,
+		metadata, // in JSON format
+	} = input;
+
+	// Type conversions
+	const _expiresAt = expiresAt
+		? Math.round(expiresAt.getTime() / 1000)
+		: undefined;
+	const _createdAt = createdAt
+		? Math.round(createdAt.getTime() / 1000)
+		: undefined;
+	const _allowedScopes = allowedScopes?.join(" ");
+	const rest = metadata ? JSON.parse(metadata) : undefined;
+
+	return {
+		// Important Fields
+		client_id: clientId,
+		client_secret: clientSecret,
+		client_secret_expires_at: clientSecret ? (_expiresAt ?? 0) : undefined,
+		scope: _allowedScopes,
+		// Recommended client data
+		user_id: userId,
+		client_id_issued_at: _createdAt,
+		// UI Metadata
+		client_name: name,
+		client_uri: uri,
+		logo_uri: icon,
+		contacts,
+		tos_uri: tos,
+		policy_uri: policy,
+		// Jwks (only one can be used)
+		// jwks, // Not Stored
+		// jwks_uri: jwksUri, // Not Stored
+		// User Software Identifiers
+		software_id: softwareId,
+		software_version: softwareVersion,
+		software_statement: softwareStatement,
+		// Authentication Metadata
+		redirect_uris: redirectUris,
+		token_endpoint_auth_method: tokenEndpointAuthMethod,
+		grant_types: grantTypes,
+		response_types: responseTypes,
+		// RFC6749 Spec
+		public: _public,
+		type,
+		// Not Part of RFC7591 Spec
+		disabled,
+		skip_consent: skipConsent,
+		// All other metadata
+		...(cleaned ? undefined : rest),
+	};
+}

--- a/packages/better-auth/src/plugins/oauth-provider/revoke.test.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/revoke.test.ts
@@ -139,7 +139,7 @@ describe("oauth revoke", async () => {
 
 	// Registers a confidential client application to work with
 	beforeAll(async () => {
-		const response = await auth.api.registerOAuthClient({
+		const response = await auth.api.createOAuthClient({
 			headers,
 			body: {
 				redirect_uris: [redirectUri],
@@ -307,7 +307,7 @@ describe("oauth revoke - config", async () => {
 			},
 		});
 
-		const registeredClient = await auth.api.registerOAuthClient({
+		const registeredClient = await auth.api.createOAuthClient({
 			headers,
 			body: {
 				redirect_uris: [redirectUri],

--- a/packages/better-auth/src/plugins/oauth-provider/revoke.test.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/revoke.test.ts
@@ -1,0 +1,427 @@
+import { beforeAll, describe, it, expect } from "vitest";
+import { getTestInstance } from "../../test-utils/test-instance";
+import { jwt } from "../jwt";
+import { oauthProvider } from "./oauth";
+import type { OAuthOptions } from "./types";
+import { createAuthClient } from "../../client";
+import type { OAuthClient } from "../../oauth-2.1/types";
+import { oauthProviderClient } from "./client";
+import {
+	createAuthorizationCodeRequest,
+	createAuthorizationURL,
+} from "../../oauth2";
+import { generateRandomString } from "../../crypto";
+import type { MakeRequired } from "../../types/helper";
+
+describe("oauth revoke", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const rpBaseUrl = "http://localhost:5000";
+	const validAudience = "https://myapi.example.com";
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			jwt({
+				jwt: {
+					audience: validAudience,
+					issuer: authServerBaseUrl,
+				},
+			}),
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+		],
+	});
+
+	const { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: {
+			customFetchImpl,
+			headers,
+		},
+	});
+
+	let oauthClient: OAuthClient | null;
+
+	const providerId = "test";
+	const redirectUri = `${rpBaseUrl}/api/auth/oauth2/callback/${providerId}`;
+	const state = "123";
+
+	async function createAuthUrl(
+		overrides?: Partial<Parameters<typeof createAuthorizationURL>[0]>,
+	) {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+		const codeVerifier = generateRandomString(32);
+		const url = await createAuthorizationURL({
+			id: providerId,
+			options: {
+				clientId: oauthClient?.client_id,
+				clientSecret: oauthClient?.client_secret,
+				redirectURI: redirectUri,
+			},
+			redirectURI: "",
+			authorizationEndpoint: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
+			state,
+			scopes: ["openid", "profile", "email", "offline_access"],
+			codeVerifier,
+			...overrides,
+		});
+		return {
+			url,
+			codeVerifier,
+		};
+	}
+
+	async function validateAuthCode(
+		overrides: MakeRequired<
+			Partial<Parameters<typeof createAuthorizationCodeRequest>[0]>,
+			"code"
+		>,
+	) {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const { body, headers } = createAuthorizationCodeRequest({
+			...overrides,
+			redirectURI: redirectUri,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+		});
+
+		const tokens = await client.$fetch<{
+			access_token?: string;
+			id_token?: string;
+			refresh_token?: string;
+			expires_in?: number;
+			expires_at?: number;
+			token_type?: string;
+			scope?: string;
+			[key: string]: unknown;
+		}>("/oauth2/token", {
+			method: "POST",
+			body: body,
+			headers: headers,
+		});
+
+		return tokens;
+	}
+
+	async function getTokens(
+		overrides?: Partial<Parameters<typeof createAuthUrl>[0]>,
+		resource?: string,
+	) {
+		const { url: authUrl, codeVerifier } = await createAuthUrl(overrides);
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		const url = new URL(callbackRedirectUrl);
+		return await validateAuthCode({
+			code: url.searchParams.get("code")!,
+			codeVerifier,
+			resource,
+		});
+	}
+
+	// Registers a confidential client application to work with
+	beforeAll(async () => {
+		const response = await auth.api.registerOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [redirectUri],
+				skip_consent: true,
+			},
+		});
+		expect(response?.client_id).toBeDefined();
+		expect(response?.user_id).toBeDefined();
+		expect(response?.client_secret).toBeDefined();
+		expect(response?.redirect_uris).toEqual([redirectUri]);
+		oauthClient = response;
+	});
+
+	it("should fail unauthenticated request", async () => {
+		const tokens = await getTokens();
+		const revocation = await client.oauth2.revoke({
+			token: tokens.data?.access_token!,
+		});
+		expect(revocation.error?.status).toBe(401);
+	});
+
+	it("should pass verification with token_type_hint access_token and sent jwt access_token", async () => {
+		const tokens = await getTokens(undefined, validAudience);
+		const revocation = await client.oauth2.revoke({
+			client_id: oauthClient?.client_id,
+			client_secret: oauthClient?.client_secret,
+			token: tokens.data?.access_token!,
+			token_type_hint: "access_token",
+		});
+		expect(revocation.data).toBe(null);
+		expect(revocation.error).toBe(null);
+	});
+
+	it("should pass verification with token_type_hint access_token and sent opaque access_token", async () => {
+		const tokens = await getTokens();
+		const revocation = await client.oauth2.revoke({
+			client_id: oauthClient?.client_id,
+			client_secret: oauthClient?.client_secret,
+			token: tokens.data?.access_token!,
+			token_type_hint: "access_token",
+		});
+		expect(revocation.data).toBe(null);
+		expect(revocation.error).toBe(null);
+	});
+
+	it("should fail with token_type_hint access_token and sent refresh_token", async () => {
+		const tokens = await getTokens();
+		const revocation = await client.oauth2.revoke({
+			client_id: oauthClient?.client_id,
+			client_secret: oauthClient?.client_secret,
+			token: tokens.data?.refresh_token!,
+			token_type_hint: "access_token",
+		});
+		expect(revocation.error?.status).toBe(400);
+	});
+
+	it("should pass verification with token_type_hint refresh_token and sent refresh_token", async () => {
+		const tokens = await getTokens();
+		const revocation = await client.oauth2.revoke({
+			client_id: oauthClient?.client_id,
+			client_secret: oauthClient?.client_secret,
+			token: tokens.data?.refresh_token!,
+			token_type_hint: "refresh_token",
+		});
+		expect(revocation.data).toBe(null);
+		expect(revocation.error).toBe(null);
+	});
+
+	it("should fail verification with token_type_hint refresh_token and sent access_token", async () => {
+		const tokens = await getTokens();
+		const revocation = await client.oauth2.revoke({
+			client_id: oauthClient?.client_id,
+			client_secret: oauthClient?.client_secret,
+			token: tokens.data?.access_token!,
+			token_type_hint: "refresh_token",
+		});
+		expect(revocation.error?.status).toBe(400);
+	});
+
+	it("should pass verification without token_type_hint and sent jwt access_token", async () => {
+		const tokens = await getTokens(undefined, validAudience);
+		const revocation = await client.oauth2.revoke({
+			client_id: oauthClient?.client_id,
+			client_secret: oauthClient?.client_secret,
+			token: tokens.data?.access_token!,
+		});
+		expect(revocation.data).toBe(null);
+		expect(revocation.error).toBe(null);
+	});
+
+	it("should pass verification without token_type_hint and sent opaque access_token", async () => {
+		const tokens = await getTokens();
+		const revocation = await client.oauth2.revoke({
+			client_id: oauthClient?.client_id,
+			client_secret: oauthClient?.client_secret,
+			token: tokens.data?.access_token!,
+		});
+		expect(revocation.data).toBe(null);
+		expect(revocation.error).toBe(null);
+	});
+
+	it("should pass verification without token_type_hint and sent refresh_token", async () => {
+		const tokens = await getTokens();
+		const revocation = await client.oauth2.revoke({
+			client_id: oauthClient?.client_id,
+			client_secret: oauthClient?.client_secret,
+			token: tokens.data?.refresh_token!,
+		});
+		expect(revocation.data).toBe(null);
+		expect(revocation.error).toBe(null);
+	});
+});
+
+describe("oauth revoke - config", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const rpBaseUrl = "http://localhost:5000";
+	const validAudience = "https://myapi.example.com";
+	const providerId = "test";
+	const redirectUri = `${rpBaseUrl}/api/auth/oauth2/callback/${providerId}`;
+	const scopes = [
+		"openid",
+		"email",
+		"profile",
+		"offline_access",
+		"read:profile",
+	];
+
+	async function createTestInstance(opts?: {
+		oauthProviderConfig?: Omit<OAuthOptions, "loginPage" | "consentPage">;
+	}) {
+		const { auth, customFetchImpl, signInWithTestUser } = await getTestInstance(
+			{
+				baseURL: authServerBaseUrl,
+				plugins: [
+					oauthProvider({
+						loginPage: "/login",
+						consentPage: "/consent",
+						scopes,
+						silenceWarnings: {
+							oauthAuthServerConfig: true,
+							openidConfig: true,
+						},
+						...opts?.oauthProviderConfig,
+					}),
+					...(opts?.oauthProviderConfig?.disableJwtPlugin
+						? []
+						: [
+								jwt({
+									jwt: {
+										audience: validAudience,
+										issuer: authServerBaseUrl,
+									},
+								}),
+							]),
+				],
+			},
+		);
+		const { headers } = await signInWithTestUser();
+		const client = createAuthClient({
+			plugins: [oauthProviderClient()],
+			baseURL: authServerBaseUrl,
+			fetchOptions: {
+				customFetchImpl,
+				headers,
+			},
+		});
+
+		const registeredClient = await auth.api.registerOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [redirectUri],
+				skip_consent: true,
+			},
+		});
+
+		return {
+			client,
+			oauthClient: registeredClient,
+		};
+	}
+
+	async function createAuthUrl(
+		oauthClient: OAuthClient,
+		overrides?: Partial<Parameters<typeof createAuthorizationURL>[0]>,
+	) {
+		const codeVerifier = generateRandomString(32);
+		const url = await createAuthorizationURL({
+			id: providerId,
+			options: {
+				clientId: oauthClient?.client_id,
+				clientSecret: oauthClient?.client_secret,
+				redirectURI: redirectUri,
+			},
+			redirectURI: "",
+			authorizationEndpoint: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
+			state: "123",
+			scopes: ["openid", "profile", "email", "offline_access"],
+			codeVerifier,
+			...overrides,
+		});
+		return {
+			url,
+			codeVerifier,
+		};
+	}
+
+	it("should pass with the correct opaqueAccessTokenPrefix", async () => {
+		const prefix = "hello_";
+		const testScopes = ["read:profile"];
+		const { client, oauthClient } = await createTestInstance({
+			oauthProviderConfig: {
+				opaqueAccessTokenPrefix: prefix,
+				scopes: testScopes,
+			},
+		});
+		const tokens = await client.oauth2.token({
+			grant_type: "client_credentials",
+			client_id: oauthClient?.client_id,
+			client_secret: oauthClient?.client_secret,
+			scope: testScopes.join(" "),
+			redirect_uri: redirectUri,
+		});
+		expect(tokens.data?.access_token?.startsWith(prefix)).toBeTruthy();
+
+		const revocation = await client.oauth2.revoke({
+			client_id: oauthClient?.client_id,
+			client_secret: oauthClient?.client_secret,
+			token: tokens.data?.access_token ?? "",
+			token_type_hint: "access_token",
+		});
+		expect(revocation.data).toBe(null);
+		expect(revocation.error).toBe(null);
+	});
+
+	it("should pass with the correct refreshTokenPrefix", async () => {
+		const refreshTokenPrefix = "hello_rt_";
+		const testScopes = ["openid", "offline_access"];
+		const { client, oauthClient } = await createTestInstance({
+			oauthProviderConfig: {
+				refreshTokenPrefix: refreshTokenPrefix,
+				scopes: testScopes,
+			},
+		});
+		if (!oauthClient) expect.unreachable();
+
+		const { url: authUrl, codeVerifier } = await createAuthUrl(oauthClient, {
+			scopes: testScopes,
+		});
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		const url = new URL(callbackRedirectUrl);
+		const tokens = await client.oauth2.token({
+			grant_type: "authorization_code",
+			code: url.searchParams.get("code") ?? undefined,
+			code_verifier: codeVerifier,
+			client_id: oauthClient?.client_id,
+			client_secret: oauthClient?.client_secret,
+			scope: testScopes.join(" "),
+			redirect_uri: redirectUri,
+		});
+		if ("refresh_token" in (tokens.data ?? {})) {
+			expect(
+				(tokens.data as { refresh_token?: string }).refresh_token?.startsWith(
+					refreshTokenPrefix,
+				),
+			).toBeTruthy();
+		} else {
+			expect.unreachable();
+		}
+
+		const revocation = await client.oauth2.revoke({
+			client_id: oauthClient?.client_id,
+			client_secret: oauthClient?.client_secret,
+			// @ts-expect-error refresh token sent
+			token: tokens.data?.refresh_token,
+			token_type_hint: "refresh_token",
+		});
+		expect(revocation.data).toBe(null);
+		expect(revocation.error).toBe(null);
+	});
+});

--- a/packages/better-auth/src/plugins/oauth-provider/revoke.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/revoke.ts
@@ -1,0 +1,329 @@
+import { APIError } from "better-call";
+import type { JSONWebKeySet } from "jose";
+import type { GenericEndpointContext } from "@better-auth/core";
+import {
+	basicToClientCredentials,
+	getStoredToken,
+	validateClientCredentials,
+} from "./utils";
+import type {
+	OAuthOpaqueAccessToken,
+	OAuthOptions,
+	OAuthRefreshToken,
+} from "./types";
+import { getJwtPlugin } from "./utils";
+import { decodeRefreshToken } from "./token";
+import { verifyJwsAccessToken } from "./verify";
+import { logger } from "@better-auth/core/env";
+
+/**
+ * IMPORTANT NOTES:
+ * Revocation follows RFC7009
+ * https://datatracker.ietf.org/doc/html/rfc7009
+ * - APIError: Continue catches (returnable to client)
+ * - Error: Should immediately stop catches (internal error)
+ */
+
+/**
+ * Revokes a JWT access token against the configured JWKs.
+ * (does nothing if successful since a JWT is not stored on the server)
+ */
+async function revokeJwtAccessToken(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions,
+	token: string,
+) {
+	const jwtPlugin = opts.disableJwtPlugin
+		? undefined
+		: getJwtPlugin(ctx.context);
+	const jwtPluginOptions = jwtPlugin?.options;
+
+	// Verify JWT Payload
+	try {
+		await verifyJwsAccessToken(token, {
+			jwksFetch: jwtPluginOptions?.jwks?.remoteUrl
+				? jwtPluginOptions.jwks.remoteUrl
+				: async () => {
+						const jwksRes = await jwtPlugin?.endpoints.getJwks(ctx);
+						// @ts-expect-error response is a JSONWebKeySet but within the response field
+						return jwksRes?.response as JSONWebKeySet | undefined;
+					},
+			verifyOptions: {
+				audience: jwtPluginOptions?.jwt?.audience ?? ctx.context.baseURL,
+				issuer: jwtPluginOptions?.jwt?.issuer ?? ctx.context.baseURL,
+			},
+		});
+	} catch (error) {
+		if (error instanceof Error) {
+			if (error.name === "TypeError" || error.name === "JWSInvalid") {
+				// likely an opaque token
+				throw new APIError("BAD_REQUEST", {
+					error_description: "invalid JWT signature",
+					error: "invalid_request",
+				});
+			} else if (error.name === "JWTExpired") {
+				return null;
+			} else if (error.name === "JWTInvalid") {
+				// audience or issuer mismatch
+				return null;
+			}
+			throw error;
+		}
+		throw new Error(error as unknown as string);
+	}
+}
+
+/**
+ * Searches for an opaque access token in the database and validates it
+ */
+async function revokeOpaqueAccessToken(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions,
+	token: string,
+	clientId: string,
+) {
+	let tokenValue = token;
+	if (opts.opaqueAccessTokenPrefix) {
+		if (tokenValue.startsWith(opts.opaqueAccessTokenPrefix)) {
+			tokenValue = tokenValue.replace(opts.opaqueAccessTokenPrefix, "");
+		} else {
+			throw new APIError("BAD_REQUEST", {
+				error_description: "opaque access token not found",
+				error: "invalid_request",
+			});
+		}
+	}
+	const accessToken: (OAuthOpaqueAccessToken & { id?: string }) | null =
+		await ctx.context.adapter
+			.findOne<OAuthOpaqueAccessToken>({
+				model: opts.schema?.oauthAccessToken?.modelName ?? "oauthAccessToken",
+				where: [
+					{
+						field: "token",
+						value: await getStoredToken(
+							opts.storeTokens,
+							tokenValue,
+							"access_token",
+						),
+					},
+				],
+			})
+			.then((res) => {
+				// TODO: remove join when native arrays supported
+				if (!res) return res;
+				return {
+					...res,
+					scopes: (res.scopes as unknown as string)?.split(" "),
+				} as OAuthOpaqueAccessToken;
+			});
+	if (!accessToken) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "opaque access token not found",
+			error: "invalid_request",
+		});
+	}
+	if (!accessToken.clientId || accessToken.clientId !== clientId) {
+		return null;
+	}
+
+	accessToken.id
+		? await ctx.context.adapter.delete({
+				model: opts.schema?.oauthAccessToken?.modelName ?? "oauthAccessToken",
+				where: [{ field: "id", value: accessToken.id }],
+			})
+		: await ctx.context.adapter.delete({
+				model: opts.schema?.oauthAccessToken?.modelName ?? "oauthAccessToken",
+				where: [{ field: "token", value: accessToken.token }],
+			});
+}
+
+/**
+ * Validates a refresh token in the session store.
+ */
+async function revokeRefreshToken(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions,
+	token: string,
+	clientId: string,
+) {
+	const refreshToken = await ctx.context.adapter.findOne<
+		OAuthRefreshToken & { id: string }
+	>({
+		model: opts.schema?.oauthRefreshToken?.modelName ?? "oauthRefreshToken",
+		where: [
+			{
+				field: "token",
+				value: await getStoredToken(opts.storeTokens, token, "refresh_token"),
+			},
+		],
+	});
+	if (!refreshToken) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "token not found",
+			error: "invalid_request",
+		});
+	}
+	if (!refreshToken.clientId || refreshToken.clientId !== clientId) {
+		return null;
+	}
+
+	await Promise.allSettled([
+		// Removes all access tokens associated with the refresh token
+		ctx.context.adapter.deleteMany({
+			model: opts.schema?.oauthAccessToken?.modelName ?? "oauthAccessToken",
+			where: [{ field: "refreshId", value: refreshToken.id }],
+		}),
+		// Remove the refresh token
+		ctx.context.adapter.delete({
+			model: opts.schema?.oauthRefreshToken?.modelName ?? "oauthRefreshToken",
+			where: [{ field: "id", value: refreshToken.id }],
+		}),
+	]);
+}
+
+/**
+ * We don't know the access token format so we try to validate it
+ * as a JWT first, then as an opaque token.
+ */
+async function revokeAccessToken(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions,
+	clientId: string,
+	token: string,
+) {
+	try {
+		return await revokeJwtAccessToken(ctx, opts, token);
+	} catch (err) {
+		if (err instanceof APIError) {
+			// continue
+		} else if (err instanceof Error) {
+			throw err;
+		} else {
+			throw new Error(err as unknown as string);
+		}
+	}
+	try {
+		return await revokeOpaqueAccessToken(ctx, opts, token, clientId);
+	} catch (err) {
+		if (err instanceof APIError) {
+			// nothing
+		} else if (err instanceof Error) {
+			throw err;
+		} else {
+			throw new Error("Unknown error validating access token");
+		}
+	}
+	throw new APIError("BAD_REQUEST", {
+		error_description: "Invalid access token",
+		error: "invalid_request",
+	});
+}
+
+export async function revokeEndpoint(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions,
+) {
+	let {
+		client_id,
+		client_secret,
+		token,
+		token_type_hint,
+	}: {
+		client_id?: string;
+		client_secret?: string;
+		token: string;
+		token_type_hint?: "access_token" | "refresh_token";
+	} = ctx.body;
+
+	// Convert basic authorization
+	const authorization = ctx.request?.headers.get("authorization") || null;
+	if (authorization?.startsWith("Basic ")) {
+		const res = basicToClientCredentials(authorization);
+		client_id = res?.client_id;
+		client_secret = res?.client_secret;
+	}
+	// client_id is always required, client_secret is required for confidential clients
+	if (!client_id) {
+		throw new APIError("UNAUTHORIZED", {
+			error_description: "missing required credentials",
+			error: "invalid_client",
+		});
+	}
+
+	// Check token
+	if (typeof token === "string" && token.startsWith("Bearer ")) {
+		token = token.replace("Bearer ", "");
+	}
+	if (!token?.length) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "missing a required token for introspection",
+			error: "invalid_request",
+		});
+	}
+
+	// Validate client credentials
+	const client = await validateClientCredentials(
+		ctx,
+		opts,
+		client_id,
+		client_secret,
+	);
+
+	try {
+		if (token_type_hint === undefined || token_type_hint === "access_token") {
+			try {
+				return await revokeAccessToken(ctx, opts, client.clientId, token);
+			} catch (error) {
+				if (error instanceof APIError) {
+					if (token_type_hint === "access_token") {
+						throw error;
+					} // else continue
+				} else if (error instanceof Error) {
+					throw error;
+				} else {
+					throw new Error(error as unknown as string);
+				}
+			}
+		}
+
+		if (token_type_hint === undefined || token_type_hint === "refresh_token") {
+			try {
+				const refreshToken = await decodeRefreshToken(opts, token);
+				return await revokeRefreshToken(
+					ctx,
+					opts,
+					refreshToken.token,
+					client.clientId,
+				);
+			} catch (error) {
+				if (error instanceof APIError) {
+					if (token_type_hint === "refresh_token") {
+						throw error;
+					} // else continue
+				} else if (error instanceof Error) {
+					throw error;
+				} else {
+					throw new Error(error as unknown as string);
+				}
+			}
+		}
+
+		throw new APIError("BAD_REQUEST", {
+			error_description: "token not found",
+			error: "invalid_request",
+		});
+	} catch (error) {
+		if (error instanceof APIError) {
+			if (error.name === "BAD_REQUEST") {
+				return null;
+			}
+			throw error;
+		} else if (error instanceof Error) {
+			logger.error("Introspection error:", error.message, error.stack);
+			throw new APIError("INTERNAL_SERVER_ERROR");
+		} else {
+			logger.error("Introspection error:", error);
+			throw new APIError("INTERNAL_SERVER_ERROR");
+		}
+	}
+}

--- a/packages/better-auth/src/plugins/oauth-provider/schema.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/schema.ts
@@ -1,0 +1,268 @@
+import type { BetterAuthPluginDBSchema } from "@better-auth/core/db";
+
+export const schema = {
+	oauthClient: {
+		modelName: "oauthClient",
+		fields: {
+			// Important Fields
+			clientId: {
+				type: "string",
+				unique: true,
+				required: true,
+			},
+			clientSecret: {
+				type: "string",
+				required: false,
+			},
+			disabled: {
+				type: "boolean",
+				defaultValue: false,
+				required: false,
+			},
+			skipConsent: {
+				type: "boolean",
+				required: false,
+			},
+			scopes: {
+				type: "string[]",
+				required: false,
+			},
+			// Recommended client data
+			userId: {
+				type: "string",
+				required: false,
+				references: {
+					model: "user",
+					field: "id",
+				},
+			},
+			createdAt: {
+				type: "date",
+				required: false,
+			},
+			updatedAt: {
+				type: "date",
+				required: false,
+			},
+			// UI Metadata
+			name: {
+				type: "string",
+				required: false,
+			},
+			uri: {
+				type: "string",
+				required: false,
+			},
+			icon: {
+				type: "string",
+				required: false,
+			},
+			contacts: {
+				type: "string[]",
+				required: false,
+			},
+			tos: {
+				type: "string",
+				required: false,
+			},
+			policy: {
+				type: "string",
+				required: false,
+			},
+			// User Software Identifiers
+			softwareId: {
+				type: "string",
+				required: false,
+			},
+			softwareVersion: {
+				type: "string",
+				required: false,
+			},
+			softwareStatement: {
+				type: "string",
+				required: false,
+			},
+			// Authentication Metadata
+			redirectUris: {
+				type: "string[]",
+				required: false,
+			},
+			tokenEndpointAuthMethod: {
+				type: "string",
+				required: false,
+			},
+			grantTypes: {
+				type: "string[]",
+				required: false,
+			},
+			responseTypes: {
+				type: "string[]",
+				required: false,
+			},
+			// RFC6749 Spec
+			public: {
+				type: "boolean",
+				required: false,
+			},
+			type: {
+				type: "string",
+				required: false,
+			},
+			// All other metadata
+			metadata: {
+				type: "json",
+				required: false,
+			},
+		},
+	},
+	/**
+	 * An opaque refresh token created with "offline_access"
+	 *
+	 * Refresh tokens are linked to a session.
+	 */
+	oauthRefreshToken: {
+		fields: {
+			token: {
+				type: "string",
+				required: true,
+			},
+			clientId: {
+				type: "string",
+				required: true,
+				references: {
+					model: "oauthClient",
+					field: "clientId",
+				},
+			},
+			// Session used during authorization
+			sessionId: {
+				type: "string",
+				required: false,
+				references: {
+					model: "session",
+					field: "id",
+					// session can be deleted but refresh still active
+					onDelete: "set null",
+				},
+			},
+			userId: {
+				type: "string",
+				required: true,
+				references: {
+					model: "user",
+					field: "id",
+				},
+			},
+			expiresAt: {
+				type: "date",
+			},
+			createdAt: {
+				type: "date",
+			},
+			// Immutable
+			scopes: {
+				type: "string[]",
+				required: true,
+			},
+		},
+	},
+	/**
+	 * An opaque access token sent when there is no audience
+	 * to assigned to the JWT.
+	 *
+	 * Access tokens are linked to a session, better-auth
+	 * authors SHALL always check for valid session!
+	 *
+	 * AccessTokens SHALL only be created at refresh,
+	 * destroyed at revoke, and read at introspection.
+	 * NEVER update an access token! Typically a refresh and
+	 * revoke (if not expired) may want to occur at the same time.
+	 */
+	oauthAccessToken: {
+		modelName: "oauthAccessToken",
+		fields: {
+			token: {
+				type: "string",
+				unique: true,
+			},
+			clientId: {
+				type: "string",
+				required: true,
+				references: {
+					model: "oauthClient",
+					field: "clientId",
+				},
+			},
+			sessionId: {
+				type: "string",
+				// Optional for client credentials grant
+				required: false,
+				// Not unique, multiple sessions could exist
+				references: {
+					model: "session",
+					field: "id",
+					// session can be deleted but refresh still active
+					onDelete: "set null",
+				},
+			},
+			userId: {
+				type: "string",
+				required: false,
+				references: {
+					model: "user",
+					field: "id",
+				},
+			},
+			refreshId: {
+				type: "string",
+				required: false,
+				references: {
+					model: "oauthRefreshToken",
+					field: "id",
+				},
+			},
+			expiresAt: {
+				type: "date",
+			},
+			createdAt: {
+				type: "date",
+			},
+			// Shall be same as refreshId.scopes if using refreshId
+			scopes: {
+				type: "string[]",
+				required: true,
+			},
+		},
+	},
+	oauthConsent: {
+		modelName: "oauthConsent",
+		fields: {
+			clientId: {
+				type: "string",
+				references: {
+					model: "oauthClient",
+					field: "clientId",
+				},
+			},
+			userId: {
+				type: "string",
+				references: {
+					model: "user",
+					field: "id",
+				},
+			},
+			scopes: {
+				type: "string",
+			},
+			createdAt: {
+				type: "date",
+			},
+			updatedAt: {
+				type: "date",
+			},
+			consentGiven: {
+				type: "boolean",
+			},
+		},
+	},
+} satisfies BetterAuthPluginDBSchema;

--- a/packages/better-auth/src/plugins/oauth-provider/token.test.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/token.test.ts
@@ -1,0 +1,1328 @@
+import { beforeAll, describe, it, expect } from "vitest";
+import { getTestInstance } from "../../test-utils/test-instance";
+import { oauthProvider } from "./oauth";
+import type { OAuthOptions } from "./types";
+import type { OAuthClient } from "../../oauth-2.1/types";
+import { createAuthClient } from "../../client";
+import { oauthProviderClient } from "./client";
+import { jwt } from "../jwt";
+import {
+	createAuthorizationCodeRequest,
+	createAuthorizationURL,
+	createRefreshAccessTokenRequest,
+} from "../../oauth2";
+import type { ProviderOptions } from "../../oauth2";
+import { generateRandomString } from "../../crypto";
+import type { MakeRequired } from "../../types/helper";
+import { createLocalJWKSet, decodeJwt, jwtVerify } from "jose";
+import { createClientCredentialsTokenRequest } from "@better-auth/core/oauth2";
+import { jwtClient } from "../jwt/client";
+
+describe("oauth token - authorization_code", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const rpBaseUrl = "http://localhost:5000";
+	const validAudience = "https://myapi.example.com";
+	const { auth, signInWithTestUser, customFetchImpl, testUser } =
+		await getTestInstance({
+			baseURL: authServerBaseUrl,
+			plugins: [
+				jwt({
+					jwt: {
+						audience: validAudience,
+						issuer: authServerBaseUrl,
+					},
+				}),
+				oauthProvider({
+					loginPage: "/login",
+					consentPage: "/oauth2/authorize",
+					silenceWarnings: {
+						oauthAuthServerConfig: true,
+						openidConfig: true,
+					},
+				}),
+			],
+		});
+
+	const { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [oauthProviderClient(), jwtClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: {
+			customFetchImpl,
+			headers,
+		},
+	});
+
+	let oauthClient: OAuthClient | null;
+
+	const providerId = "test";
+	const redirectUri = `${rpBaseUrl}/api/auth/oauth2/callback/${providerId}`;
+	const state = "123";
+	let jwks: ReturnType<typeof createLocalJWKSet>;
+
+	// Registers a confidential client application to work with
+	beforeAll(async () => {
+		const response = await auth.api.registerOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [redirectUri],
+				skip_consent: true,
+			},
+		});
+		expect(response?.client_id).toBeDefined();
+		expect(response?.user_id).toBeDefined();
+		expect(response?.client_secret).toBeDefined();
+		expect(response?.redirect_uris).toEqual([redirectUri]);
+		oauthClient = response;
+
+		// Get jwks
+		const jwksResult = await client.jwks();
+		if (!jwksResult.data) {
+			throw new Error("Unable to fetch jwks");
+		}
+		jwks = createLocalJWKSet(jwksResult.data);
+	});
+
+	async function createAuthUrl(
+		overrides?: Partial<Parameters<typeof createAuthorizationURL>[0]>,
+	) {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+		const codeVerifier = generateRandomString(32);
+		const url = await createAuthorizationURL({
+			id: providerId,
+			options: {
+				clientId: oauthClient?.client_id,
+				clientSecret: oauthClient?.client_secret,
+				redirectURI: redirectUri,
+			},
+			redirectURI: "",
+			authorizationEndpoint: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
+			state,
+			scopes: ["openid", "profile", "email", "offline_access"],
+			codeVerifier,
+			...overrides,
+		});
+		return {
+			url,
+			codeVerifier,
+		};
+	}
+
+	async function validateAuthCode(
+		overrides: MakeRequired<
+			Partial<Parameters<typeof createAuthorizationCodeRequest>[0]>,
+			"code"
+		>,
+	) {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const { body, headers } = createAuthorizationCodeRequest({
+			...overrides,
+			redirectURI: redirectUri,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+		});
+
+		const tokens = await client.$fetch<{
+			access_token?: string;
+			id_token?: string;
+			refresh_token?: string;
+			expires_in?: number;
+			expires_at?: number;
+			token_type?: string;
+			scope?: string;
+			[key: string]: unknown;
+		}>("/oauth2/token", {
+			method: "POST",
+			body: body,
+			headers: headers,
+		});
+
+		return tokens;
+	}
+
+	it("scope openid should provide access_token and id_token", async ({
+		expect,
+	}) => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const scopes = ["openid"];
+		const { url: authUrl, codeVerifier } = await createAuthUrl({
+			scopes,
+		});
+
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		expect(callbackRedirectUrl).toContain(redirectUri);
+		expect(callbackRedirectUrl).toContain(`code=`);
+		expect(callbackRedirectUrl).toContain(`state=123`);
+		const url = new URL(callbackRedirectUrl);
+
+		const tokens = await validateAuthCode({
+			code: url.searchParams.get("code")!,
+			codeVerifier,
+		});
+		expect(tokens.data?.access_token).toBeDefined(); // Note: Opaque
+		expect(tokens.data?.id_token).toBeDefined();
+		expect(tokens.data?.refresh_token).toBeUndefined();
+		expect(tokens.data?.scope).toBe(scopes.join(" "));
+
+		const idToken = await jwtVerify(tokens.data?.id_token!, jwks);
+		expect(idToken.protectedHeader).toBeDefined();
+		expect(idToken.payload).toBeDefined();
+		expect(idToken.payload.sub).toBeDefined();
+		expect(idToken.payload.name).toBeUndefined();
+		expect(idToken.payload.email).toBeUndefined();
+	});
+
+	it("scope openid+profile should provide access_token and id_token", async ({
+		expect,
+	}) => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const scopes = ["openid", "profile"];
+		const { url: authUrl, codeVerifier } = await createAuthUrl({
+			scopes,
+		});
+
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		expect(callbackRedirectUrl).toContain(redirectUri);
+		expect(callbackRedirectUrl).toContain(`code=`);
+		expect(callbackRedirectUrl).toContain(`state=123`);
+		const url = new URL(callbackRedirectUrl);
+
+		const tokens = await validateAuthCode({
+			code: url.searchParams.get("code")!,
+			codeVerifier,
+		});
+		expect(tokens.data?.access_token).toBeDefined();
+		expect(tokens.data?.id_token).toBeDefined();
+		expect(tokens.data?.refresh_token).toBeUndefined();
+		expect(tokens.data?.scope).toBe(scopes.join(" "));
+
+		const idToken = await jwtVerify(tokens.data?.id_token!, jwks);
+		expect(idToken.protectedHeader).toBeDefined();
+		expect(idToken.payload).toBeDefined();
+		expect(idToken.payload.sub).toBeDefined();
+		expect(idToken.payload.name).toBe(testUser.name);
+		expect(idToken.payload.email).toBeUndefined();
+	});
+
+	it("scope openid+email should provide access_token and id_token", async ({
+		expect,
+	}) => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const scopes = ["openid", "email"];
+		const { url: authUrl, codeVerifier } = await createAuthUrl({
+			scopes,
+		});
+
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		expect(callbackRedirectUrl).toContain(redirectUri);
+		expect(callbackRedirectUrl).toContain(`code=`);
+		expect(callbackRedirectUrl).toContain(`state=123`);
+		const url = new URL(callbackRedirectUrl);
+
+		const tokens = await validateAuthCode({
+			code: url.searchParams.get("code")!,
+			codeVerifier,
+		});
+		expect(tokens.data?.access_token).toBeDefined();
+		expect(tokens.data?.id_token).toBeDefined();
+		expect(tokens.data?.refresh_token).toBeUndefined();
+		expect(tokens.data?.scope).toBe(scopes.join(" "));
+
+		const idToken = await jwtVerify(tokens.data?.id_token!, jwks);
+		expect(idToken.protectedHeader).toBeDefined();
+		expect(idToken.payload).toBeDefined();
+		expect(idToken.payload.sub).toBeDefined();
+		expect(idToken.payload.name).toBeUndefined();
+		expect(idToken.payload.email).toBe(testUser.email);
+	});
+
+	it("scope openid+offline_access should provide opaque access_token, id_token, and refresh_token", async ({
+		expect,
+	}) => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const scopes = ["openid", "offline_access"];
+		const { url: authUrl, codeVerifier } = await createAuthUrl({
+			scopes,
+		});
+
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		expect(callbackRedirectUrl).toContain(redirectUri);
+		expect(callbackRedirectUrl).toContain(`code=`);
+		expect(callbackRedirectUrl).toContain(`state=123`);
+		const url = new URL(callbackRedirectUrl);
+
+		const tokens = await validateAuthCode({
+			code: url.searchParams.get("code")!,
+			codeVerifier,
+		});
+		expect(tokens.data?.access_token).toBeDefined();
+		expect(tokens.data?.id_token).toBeDefined();
+		expect(tokens.data?.refresh_token).toBeDefined();
+		expect(tokens.data?.scope).toBe(scopes.join(" "));
+
+		const idToken = await jwtVerify(tokens.data?.id_token!, jwks);
+		expect(idToken.protectedHeader).toBeDefined();
+		expect(idToken.payload).toBeDefined();
+		expect(idToken.payload.sub).toBeDefined();
+		expect(idToken.payload.name).toBeUndefined();
+		expect(idToken.payload.email).toBeUndefined();
+	});
+
+	it("scope openid+offline_access & specified resource should provide JWT access_token, id_token, and refresh_token", async ({
+		expect,
+	}) => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const scopes = ["openid", "offline_access"];
+		const { url: authUrl, codeVerifier } = await createAuthUrl({
+			scopes,
+		});
+
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		expect(callbackRedirectUrl).toContain(redirectUri);
+		expect(callbackRedirectUrl).toContain(`code=`);
+		expect(callbackRedirectUrl).toContain(`state=123`);
+		const url = new URL(callbackRedirectUrl);
+
+		const tokens = await validateAuthCode({
+			code: url.searchParams.get("code")!,
+			codeVerifier,
+			resource: validAudience,
+		});
+		expect(tokens.data?.access_token).toBeDefined();
+		expect(tokens.data?.id_token).toBeDefined();
+		expect(tokens.data?.refresh_token).toBeDefined();
+		expect(tokens.data?.scope).toBe(scopes.join(" "));
+
+		const idToken = await jwtVerify(tokens.data?.id_token!, jwks);
+		expect(idToken.protectedHeader).toBeDefined();
+		expect(idToken.payload).toBeDefined();
+		expect(idToken.payload.sub).toBeDefined();
+		expect(idToken.payload.name).toBeUndefined();
+		expect(idToken.payload.email).toBeUndefined();
+
+		const accessToken = await jwtVerify(tokens.data?.access_token!, jwks, {
+			audience: validAudience,
+			issuer: authServerBaseUrl,
+		});
+		expect(accessToken.payload.azp).toBe(oauthClient.client_id);
+		expect(accessToken.payload.sub).toBeDefined();
+		expect(accessToken.payload.iat).toBeDefined();
+		expect(accessToken.payload.exp).toBe(tokens.data?.expires_at);
+		expect(accessToken.payload.scope).toBe(scopes.join(" "));
+	});
+});
+
+describe("oauth token - refresh_token", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const rpBaseUrl = "http://localhost:5000";
+	const validAudience = "https://myapi.example.com";
+	const {
+		auth: authorizationServer,
+		signInWithTestUser,
+		customFetchImpl,
+	} = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			jwt({
+				jwt: {
+					audience: validAudience,
+					issuer: authServerBaseUrl,
+				},
+			}),
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/oauth2/authorize",
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+		],
+	});
+
+	const { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [oauthProviderClient(), jwtClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: {
+			customFetchImpl,
+			headers,
+		},
+	});
+
+	let oauthClient: OAuthClient | null;
+
+	const providerId = "test";
+	const redirectUri = `${rpBaseUrl}/api/auth/oauth2/callback/${providerId}`;
+	const state = "123";
+	let jwks: ReturnType<typeof createLocalJWKSet>;
+
+	// Registers a confidential client application to work with
+	beforeAll(async () => {
+		const response = await authorizationServer.api.registerOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [redirectUri],
+				skip_consent: true,
+			},
+		});
+		expect(response?.client_id).toBeDefined();
+		expect(response?.user_id).toBeDefined();
+		expect(response?.client_secret).toBeDefined();
+		expect(response?.redirect_uris).toEqual([redirectUri]);
+		oauthClient = response;
+
+		// Get jwks
+		const jwksResult = await client.jwks();
+		if (!jwksResult.data) {
+			throw new Error("Unable to fetch jwks");
+		}
+		jwks = createLocalJWKSet(jwksResult.data);
+	});
+
+	async function createAuthUrl(
+		overrides?: Partial<Parameters<typeof createAuthorizationURL>[0]>,
+	) {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+		const codeVerifier = generateRandomString(32);
+		const url = await createAuthorizationURL({
+			id: providerId,
+			options: {
+				clientId: oauthClient?.client_id,
+				clientSecret: oauthClient?.client_secret,
+				redirectURI: redirectUri,
+			},
+			redirectURI: "",
+			authorizationEndpoint: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
+			state,
+			scopes: ["openid", "profile", "email", "offline_access"],
+			codeVerifier,
+			...overrides,
+		});
+		return {
+			url,
+			codeVerifier,
+		};
+	}
+
+	async function validateAuthCode(
+		overrides: MakeRequired<
+			Partial<Parameters<typeof createAuthorizationCodeRequest>[0]>,
+			"code"
+		>,
+	) {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const { body, headers } = createAuthorizationCodeRequest({
+			...overrides,
+			redirectURI: redirectUri,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+		});
+
+		const tokens = await client.$fetch<{
+			access_token?: string;
+			id_token?: string;
+			refresh_token?: string;
+			expires_in?: number;
+			expires_at?: number;
+			token_type?: string;
+			scope?: string;
+			[key: string]: unknown;
+		}>("/oauth2/token", {
+			method: "POST",
+			body: body,
+			headers: headers,
+		});
+
+		return tokens;
+	}
+
+	/** Initial authorization */
+	async function authorizeForRefreshToken(scopes: string[]) {
+		const { url: authUrl, codeVerifier } = await createAuthUrl({
+			scopes,
+		});
+
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		expect(callbackRedirectUrl).toContain(redirectUri);
+		expect(callbackRedirectUrl).toContain(`code=`);
+		expect(callbackRedirectUrl).toContain(`state=123`);
+		const url = new URL(callbackRedirectUrl);
+
+		const tokens = await validateAuthCode({
+			code: url.searchParams.get("code")!,
+			codeVerifier,
+		});
+		expect(tokens.data?.access_token).toBeDefined();
+		expect(tokens.data?.id_token).toBeDefined();
+		expect(tokens.data?.refresh_token).toBeDefined();
+		expect(tokens.data?.scope).toBe(scopes.join(" "));
+
+		const idToken = await jwtVerify(tokens.data?.id_token!, jwks);
+		expect(idToken.protectedHeader).toBeDefined();
+		expect(idToken.payload).toBeDefined();
+		expect(idToken.payload.sub).toBeDefined();
+		expect(idToken.payload.name).toBeDefined();
+		expect(idToken.payload.email).toBeUndefined();
+
+		return tokens.data;
+	}
+
+	it("should refresh token with same scopes, opaque access token", async ({
+		expect,
+	}) => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const scopes = ["openid", "profile", "offline_access"];
+		const tokens = await authorizeForRefreshToken(scopes);
+		expect(tokens?.refresh_token).toBeDefined();
+
+		// Refresh tokens
+		const { body, headers } = createRefreshAccessTokenRequest({
+			refreshToken: tokens?.refresh_token!,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+			extraParams: {
+				scope: scopes.join(" "),
+			},
+		});
+		const newTokens = await client.$fetch<{
+			access_token?: string;
+			id_token?: string;
+			refresh_token?: string;
+			expires_in?: number;
+			expires_at?: number;
+			token_type?: string;
+			scope?: string;
+			[key: string]: unknown;
+		}>("/oauth2/token", {
+			method: "POST",
+			body: body,
+			headers: headers,
+		});
+		expect(newTokens.data?.access_token).toBeDefined();
+		expect(newTokens.data?.id_token).toBeDefined();
+		expect(newTokens.data?.refresh_token).toBeDefined();
+		expect(newTokens.data?.scope).toBe(scopes.join(" "));
+
+		// Always expect a new refresh token
+		expect(tokens?.refresh_token).not.toEqual(newTokens.data?.refresh_token);
+	});
+
+	it("should refresh token with same scopes, JWT access token", async ({
+		expect,
+	}) => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const scopes = ["openid", "profile", "offline_access"];
+		const tokens = await authorizeForRefreshToken(scopes);
+		expect(tokens?.refresh_token).toBeDefined();
+
+		// Refresh tokens
+		const { body, headers } = createRefreshAccessTokenRequest({
+			refreshToken: tokens?.refresh_token!,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+			extraParams: {
+				scope: scopes.join(" "),
+			},
+			resource: validAudience,
+		});
+		const newTokens = await client.$fetch<{
+			access_token?: string;
+			id_token?: string;
+			refresh_token?: string;
+			expires_in?: number;
+			expires_at?: number;
+			token_type?: string;
+			scope?: string;
+			[key: string]: unknown;
+		}>("/oauth2/token", {
+			method: "POST",
+			body: body,
+			headers: headers,
+		});
+		expect(newTokens.data?.access_token).toBeDefined();
+		expect(newTokens.data?.id_token).toBeDefined();
+		expect(newTokens.data?.refresh_token).toBeDefined();
+		expect(newTokens.data?.scope).toBe(scopes.join(" "));
+
+		// Always expect a new refresh token
+		expect(tokens?.refresh_token).not.toEqual(newTokens.data?.refresh_token);
+
+		const accessToken = await jwtVerify(newTokens.data?.access_token!, jwks, {
+			audience: validAudience,
+			issuer: authServerBaseUrl,
+		});
+		expect(accessToken.payload.azp).toBe(oauthClient.client_id);
+		expect(accessToken.payload.sub).toBeDefined();
+		expect(accessToken.payload.iat).toBeDefined();
+		expect(accessToken.payload.exp).toBe(newTokens.data?.expires_at);
+		expect(accessToken.payload.scope).toBe(scopes.join(" "));
+	});
+
+	it("should refresh token with lesser scopes, opaque access token", async ({
+		expect,
+	}) => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const scopes = ["openid", "profile", "offline_access"];
+		const newScopes = ["openid", "offline_access"];
+		const tokens = await authorizeForRefreshToken(scopes);
+		expect(tokens?.refresh_token).toBeDefined();
+
+		// Refresh tokens
+		const { body, headers } = createRefreshAccessTokenRequest({
+			refreshToken: tokens?.refresh_token!,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+			extraParams: {
+				scope: newScopes.join(" "),
+			},
+		});
+		const newTokens = await client.$fetch<{
+			access_token?: string;
+			id_token?: string;
+			refresh_token?: string;
+			expires_in?: number;
+			expires_at?: number;
+			token_type?: string;
+			scope?: string;
+			[key: string]: unknown;
+		}>("/oauth2/token", {
+			method: "POST",
+			body: body,
+			headers: headers,
+		});
+		expect(newTokens.data?.access_token).toBeDefined();
+		expect(newTokens.data?.id_token).toBeDefined();
+		expect(newTokens.data?.refresh_token).toBeDefined();
+		expect(newTokens.data?.scope).toBe(newScopes.join(" "));
+
+		// Always expect a new refresh token
+		expect(tokens?.refresh_token).not.toEqual(newTokens.data?.refresh_token);
+	});
+
+	it("should refresh token with lesser scopes, JWT access token", async ({
+		expect,
+	}) => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const scopes = ["openid", "profile", "offline_access"];
+		const newScopes = ["openid", "offline_access"];
+		const tokens = await authorizeForRefreshToken(scopes);
+		expect(tokens?.refresh_token).toBeDefined();
+
+		// Refresh tokens
+		const { body, headers } = createRefreshAccessTokenRequest({
+			refreshToken: tokens?.refresh_token!,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+			extraParams: {
+				scope: newScopes.join(" "),
+			},
+			resource: validAudience,
+		});
+		const newTokens = await client.$fetch<{
+			access_token?: string;
+			id_token?: string;
+			refresh_token?: string;
+			expires_in?: number;
+			expires_at?: number;
+			token_type?: string;
+			scope?: string;
+			[key: string]: unknown;
+		}>("/oauth2/token", {
+			method: "POST",
+			body: body,
+			headers: headers,
+		});
+		expect(newTokens.data?.access_token).toBeDefined();
+		expect(newTokens.data?.id_token).toBeDefined();
+		expect(newTokens.data?.refresh_token).toBeDefined();
+		expect(newTokens.data?.scope).toBe(newScopes.join(" "));
+
+		// Always expect a new refresh token
+		expect(tokens?.refresh_token).not.toEqual(newTokens.data?.refresh_token);
+
+		const accessToken = await jwtVerify(newTokens.data?.access_token!, jwks, {
+			audience: validAudience,
+			issuer: authServerBaseUrl,
+		});
+		expect(accessToken.payload.azp).toBe(oauthClient.client_id);
+		expect(accessToken.payload.sub).toBeDefined();
+		expect(accessToken.payload.iat).toBeDefined();
+		expect(accessToken.payload.exp).toBe(newTokens.data?.expires_at);
+		expect(accessToken.payload.scope).toBe(newScopes.join(" "));
+	});
+
+	it("should not refresh token when removing offline_scope", async ({
+		expect,
+	}) => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const scopes = ["openid", "profile", "offline_access"];
+		const newScopes = ["openid"];
+		const tokens = await authorizeForRefreshToken(scopes);
+		expect(tokens?.refresh_token).toBeDefined();
+
+		// Refresh tokens
+		const { body, headers } = createRefreshAccessTokenRequest({
+			refreshToken: tokens?.refresh_token!,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+			extraParams: {
+				scope: newScopes.join(" "),
+			},
+		});
+		const newTokens = await client.$fetch<{
+			access_token?: string;
+			id_token?: string;
+			refresh_token?: string;
+			expires_in?: number;
+			expires_at?: number;
+			token_type?: string;
+			scope?: string;
+			[key: string]: unknown;
+		}>("/oauth2/token", {
+			method: "POST",
+			body: body,
+			headers: headers,
+		});
+		expect(newTokens.data?.access_token).toBeDefined();
+		expect(newTokens.data?.id_token).toBeDefined();
+		expect(newTokens.data?.refresh_token).toBeUndefined();
+		expect(newTokens.data?.scope).toBe(newScopes.join(" "));
+
+		// Should not refresh token
+		expect(tokens?.refresh_token).not.toEqual(newTokens.data?.refresh_token);
+	});
+
+	it("should not refresh token with more scopes", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const scopes = ["openid", "profile", "offline_access"];
+		const newScopes = ["openid", "email", "offline_access"];
+		const tokens = await authorizeForRefreshToken(scopes);
+		expect(tokens?.refresh_token).toBeDefined();
+
+		// Refresh tokens
+		const { body, headers } = createRefreshAccessTokenRequest({
+			refreshToken: tokens?.refresh_token!,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+			extraParams: {
+				scope: newScopes.join(" "),
+			},
+		});
+		const newTokens = await client.$fetch<{
+			access_token?: string;
+			id_token?: string;
+			refresh_token?: string;
+			expires_in?: number;
+			expires_at?: number;
+			token_type?: string;
+			scope?: string;
+			[key: string]: unknown;
+		}>("/oauth2/token", {
+			method: "POST",
+			body: body,
+			headers: headers,
+		});
+		expect(newTokens.error?.status).toBeDefined();
+	});
+});
+
+describe("oauth token - client_credentials", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const rpBaseUrl = "http://localhost:5000";
+	const validAudience = "https://myapi.example.com";
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			jwt({
+				jwt: {
+					audience: validAudience,
+					issuer: authServerBaseUrl,
+				},
+			}),
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/oauth2/authorize",
+				allowDynamicClientRegistration: true,
+				scopes: ["openid", "profile", "email", "read:posts"],
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+		],
+	});
+
+	const { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [oauthProviderClient(), jwtClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: {
+			customFetchImpl,
+			headers,
+		},
+	});
+
+	let oauthClient: OAuthClient | null;
+
+	const providerId = "test";
+	const redirectUri = `${rpBaseUrl}/api/auth/oauth2/callback/${providerId}`;
+	let jwks: ReturnType<typeof createLocalJWKSet>;
+
+	// Registers a confidential client application to work with
+	beforeAll(async () => {
+		const response = await auth.api.registerOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [redirectUri],
+				skip_consent: true,
+			},
+		});
+		expect(response?.client_id).toBeDefined();
+		expect(response?.user_id).toBeDefined();
+		expect(response?.client_secret).toBeDefined();
+		expect(response?.redirect_uris).toEqual([redirectUri]);
+		oauthClient = response;
+
+		// Get jwks
+		const jwksResult = await client.jwks();
+		if (!jwksResult.data) {
+			throw new Error("Unable to fetch jwks");
+		}
+		jwks = createLocalJWKSet(jwksResult.data);
+	});
+
+	it("should obtain an opaque access token", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const scopes = ["read:posts"];
+		const { body, headers } = createClientCredentialsTokenRequest({
+			scope: scopes.join(" "),
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+		});
+		const tokens = await client.$fetch<{
+			access_token?: string;
+			id_token?: string;
+			refresh_token?: string;
+			expires_in?: number;
+			expires_at?: number;
+			token_type?: string;
+			scope?: string;
+			[key: string]: unknown;
+		}>("/oauth2/token", {
+			method: "POST",
+			body: body,
+			headers: headers,
+		});
+		expect(tokens.data?.access_token).toBeDefined();
+		expect(tokens.data?.id_token).toBeUndefined();
+		expect(tokens.data?.refresh_token).toBeUndefined();
+		expect(tokens.data?.scope).toBe(scopes.join(" "));
+		expect(tokens.data?.expires_in).toBe(3600);
+		expect(tokens.data?.expires_at).toBeDefined();
+	});
+
+	it("should fail without requested scope and clientCredentialGrantDefaultScopes not set", async ({
+		expect,
+	}) => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const { body, headers } = createClientCredentialsTokenRequest({
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+		});
+		const tokens = await client.$fetch<{
+			access_token?: string;
+			id_token?: string;
+			refresh_token?: string;
+			expires_in?: number;
+			expires_at?: number;
+			token_type?: string;
+			scope?: string;
+			[key: string]: unknown;
+		}>("/oauth2/token", {
+			method: "POST",
+			body: body,
+			headers: headers,
+		});
+		expect(tokens.error?.status).toBeDefined();
+	});
+
+	it("should obtain a JWT access token", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const scopes = ["read:posts"];
+		const { body, headers } = createClientCredentialsTokenRequest({
+			scope: scopes.join(" "),
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+			resource: validAudience,
+		});
+		const tokens = await client.$fetch<{
+			access_token?: string;
+			id_token?: string;
+			refresh_token?: string;
+			expires_in?: number;
+			expires_at?: number;
+			token_type?: string;
+			scope?: string;
+			[key: string]: unknown;
+		}>("/oauth2/token", {
+			method: "POST",
+			body: body,
+			headers: headers,
+		});
+		expect(tokens.data?.access_token).toBeDefined();
+		expect(tokens.data?.id_token).toBeUndefined();
+		expect(tokens.data?.refresh_token).toBeUndefined();
+		expect(tokens.data?.scope).toBe(scopes.join(" "));
+		expect(tokens.data?.expires_in).toBe(3600);
+		expect(tokens.data?.expires_at).toBeDefined();
+
+		const accessToken = await jwtVerify(tokens.data?.access_token!, jwks, {
+			audience: validAudience,
+			issuer: authServerBaseUrl,
+		});
+		expect(accessToken.payload.azp).toBe(oauthClient.client_id);
+		expect(accessToken.payload.sub).toBeUndefined(); // unset since not a user!
+		expect(accessToken.payload.iat).toBeDefined();
+		expect(accessToken.payload.exp).toBe(tokens.data?.expires_at);
+		expect(accessToken.payload.scope).toBe(scopes.join(" "));
+	});
+});
+
+describe("oauth token - config", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const rpBaseUrl = "http://localhost:5000";
+	const validAudience = "https://myapi.example.com";
+	const providerId = "test";
+	const redirectUri = `${rpBaseUrl}/api/auth/oauth2/callback/${providerId}`;
+
+	const state = "123";
+	const scopes = [
+		"openid",
+		"email",
+		"profile",
+		"offline_access",
+		"read:payments", // should use scopeExpirations 30m
+		"write:payments", // should use scopeExpirations 5m
+		"read:profile", // should use default
+	];
+
+	async function createTestInstance(opts?: {
+		oauthProviderConfig?: Omit<OAuthOptions, "loginPage" | "consentPage">;
+	}) {
+		const { auth, customFetchImpl, signInWithTestUser } = await getTestInstance(
+			{
+				baseURL: authServerBaseUrl,
+				plugins: [
+					oauthProvider({
+						loginPage: "/login",
+						consentPage: "/consent",
+						scopes,
+						silenceWarnings: {
+							oauthAuthServerConfig: true,
+							openidConfig: true,
+						},
+						...opts?.oauthProviderConfig,
+					}),
+					...(opts?.oauthProviderConfig?.disableJwtPlugin
+						? []
+						: [
+								jwt({
+									jwt: {
+										audience: validAudience,
+										issuer: authServerBaseUrl,
+									},
+								}),
+							]),
+				],
+			},
+		);
+		const { headers } = await signInWithTestUser();
+		const client = createAuthClient({
+			plugins: [oauthProviderClient()],
+			baseURL: authServerBaseUrl,
+			fetchOptions: {
+				customFetchImpl,
+				headers,
+			},
+		});
+
+		const registeredClient = await auth.api.registerOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [redirectUri],
+				skip_consent: true,
+			},
+		});
+
+		return {
+			client,
+			oauthClient: registeredClient,
+		};
+	}
+
+	async function createAuthUrl(
+		credentials: ProviderOptions,
+		overrides?: Partial<Parameters<typeof createAuthorizationURL>[0]>,
+	) {
+		const codeVerifier = generateRandomString(32);
+		const url = await createAuthorizationURL({
+			id: providerId,
+			options: credentials,
+			redirectURI: redirectUri,
+			authorizationEndpoint: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
+			state,
+			scopes,
+			codeVerifier,
+			...overrides,
+		});
+		return {
+			url,
+			codeVerifier,
+		};
+	}
+
+	// Client Credentials Grant
+	it.each([
+		{
+			testScopes: ["read:payments"],
+			result: 1800, // 30m lowest
+		},
+		{
+			testScopes: ["read:payments", "write:payments"],
+			result: 300, // 5m lowest
+		},
+		{
+			testScopes: ["read:profile"],
+			result: 7200, // m2m expiresIn 2hr
+		},
+	])(
+		"scopeExpirations - access token expiration $testScopes",
+		async ({ testScopes, result }) => {
+			const { client, oauthClient } = await createTestInstance({
+				oauthProviderConfig: {
+					m2mAccessTokenExpiresIn: 7200,
+					scopeExpirations: {
+						"read:payments": "30m",
+						"write:payments": "5m",
+					},
+				},
+			});
+			// Client credentials
+			const tokens = await client.oauth2.token({
+				resource: validAudience,
+				grant_type: "client_credentials",
+				client_id: oauthClient?.client_id,
+				client_secret: oauthClient?.client_secret,
+				scope: testScopes.join(" "),
+			});
+			expect(tokens.data?.expires_in).toBe(result); // 5m lowest
+			// NOTE: verification is done in other tests (we only care about the exp fields in this test)
+			const accessToken = decodeJwt(tokens.data?.access_token ?? "");
+			expect((accessToken.exp ?? 0) - (accessToken.iat ?? 0)).toBe(result); // 5m lowest
+		},
+	);
+
+	// Authorization Code and Refresh Token grants
+	it.each([
+		{
+			testScopes: ["read:payments", "offline_access"],
+			result: 1800, // 30m lowest
+		},
+		{
+			testScopes: ["read:payments", "write:payments", "offline_access"],
+			result: 300, // 5m lowest
+		},
+		{
+			testScopes: ["profile", "offline_access"],
+			result: 7200, // accessTokenExpiresIn 2hr
+		},
+	])(
+		"scopeExpirations - access token expiration $testScopes",
+		async ({ testScopes, result }) => {
+			const { client, oauthClient } = await createTestInstance({
+				oauthProviderConfig: {
+					accessTokenExpiresIn: 7200,
+					scopeExpirations: {
+						"read:payments": "30m",
+						"write:payments": "5m",
+					},
+				},
+			});
+			const { url: authUrl, codeVerifier } = await createAuthUrl(
+				{
+					clientId: oauthClient?.client_id!,
+					clientSecret: oauthClient?.client_secret,
+				},
+				{
+					scopes: testScopes,
+				},
+			);
+			let callbackRedirectUrl = "";
+			await client.$fetch(authUrl.toString(), {
+				onError(context) {
+					callbackRedirectUrl = context.response.headers.get("Location") || "";
+				},
+			});
+			expect(callbackRedirectUrl).toContain(redirectUri);
+			expect(callbackRedirectUrl).toContain(`code=`);
+			expect(callbackRedirectUrl).toContain(`state=123`);
+			const url = new URL(callbackRedirectUrl);
+
+			// Authorization code
+			const tokens = await client.oauth2.token({
+				code: url.searchParams.get("code")!,
+				code_verifier: codeVerifier,
+				grant_type: "authorization_code",
+				resource: validAudience,
+				client_id: oauthClient?.client_id,
+				client_secret: oauthClient?.client_secret,
+				redirect_uri: redirectUri,
+			});
+			expect(tokens.data?.expires_in).toBe(result); // 5m lowest
+			// NOTE: verification is done in other tests (we only care about the exp fields in this test)
+			const accessToken = decodeJwt(tokens.data?.access_token ?? "");
+			expect((accessToken.exp ?? 0) - (accessToken.iat ?? 0)).toBe(result); // 5m lowest
+
+			// Refresh token
+			const refreshedTokens = await client.oauth2.token({
+				resource: validAudience,
+				// @ts-expect-error refresh token is sent
+				refresh_token: tokens.data?.refresh_token,
+				grant_type: "refresh_token",
+				client_id: oauthClient?.client_id,
+				client_secret: oauthClient?.client_secret,
+			});
+			expect(refreshedTokens.data?.expires_in).toBe(result); // 5m lowest
+			// NOTE: verification is done in other tests (we only care about the exp fields in this test)
+			const refreshedAccessToken = decodeJwt(
+				refreshedTokens.data?.access_token ?? "",
+			);
+			expect(
+				(refreshedAccessToken.exp ?? 0) - (refreshedAccessToken.iat ?? 0),
+			).toBe(result); // 5m lowest
+		},
+	);
+
+	it("opaqueAccessTokenPrefix - client_credentials", async () => {
+		const prefix = "hello_";
+		const testScopes = ["read:profile"];
+		const { client, oauthClient } = await createTestInstance({
+			oauthProviderConfig: {
+				opaqueAccessTokenPrefix: prefix,
+			},
+		});
+		// Client credentials
+		const tokens = await client.oauth2.token({
+			grant_type: "client_credentials",
+			client_id: oauthClient?.client_id,
+			client_secret: oauthClient?.client_secret,
+			scope: testScopes.join(""),
+		});
+		expect(tokens.data?.access_token?.startsWith(prefix)).toBeTruthy();
+	});
+
+	it("opaqueAccessTokenPrefix, refreshTokenPrefix - code_authorization, refresh_token", async () => {
+		const accessTokenPrefix = "hello__ac_";
+		const refreshTokenPrefix = "hello_rt_";
+		const { client, oauthClient } = await createTestInstance({
+			oauthProviderConfig: {
+				opaqueAccessTokenPrefix: accessTokenPrefix,
+				refreshTokenPrefix: refreshTokenPrefix,
+			},
+		});
+		const { url: authUrl, codeVerifier } = await createAuthUrl({
+			clientId: oauthClient?.client_id!,
+			clientSecret: oauthClient?.client_secret,
+		});
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		expect(callbackRedirectUrl).toContain(redirectUri);
+		expect(callbackRedirectUrl).toContain(`code=`);
+		expect(callbackRedirectUrl).toContain(`state=123`);
+		const url = new URL(callbackRedirectUrl);
+
+		// Authorization code
+		const tokens = await client.oauth2.token({
+			code: url.searchParams.get("code")!,
+			code_verifier: codeVerifier,
+			grant_type: "authorization_code",
+			client_id: oauthClient?.client_id,
+			client_secret: oauthClient?.client_secret,
+			redirect_uri: redirectUri,
+		});
+		expect(
+			tokens.data?.access_token?.startsWith(accessTokenPrefix),
+		).toBeTruthy();
+		if ("refresh_token" in (tokens.data ?? {})) {
+			expect(
+				(tokens.data as { refresh_token?: string }).refresh_token?.startsWith(
+					refreshTokenPrefix,
+				),
+			).toBeTruthy();
+		} else {
+			expect.unreachable();
+		}
+
+		// Refresh token
+		const refreshedTokens = await client.oauth2.token({
+			// @ts-expect-error refresh token is sent
+			refresh_token: tokens.data?.refresh_token,
+			grant_type: "refresh_token",
+			client_id: oauthClient?.client_id,
+			client_secret: oauthClient?.client_secret,
+		});
+		expect(
+			refreshedTokens.data?.access_token?.startsWith(accessTokenPrefix),
+		).toBeTruthy();
+		if ("refresh_token" in (refreshedTokens.data ?? {})) {
+			expect(
+				(
+					refreshedTokens.data as { refresh_token?: string }
+				).refresh_token?.startsWith(refreshTokenPrefix),
+			).toBeTruthy();
+		} else {
+			expect.unreachable();
+		}
+	});
+
+	it("clientSecretPrefix - client_credentials", async () => {
+		const prefix = "hello_cs_";
+		const testScopes = ["read:profile"];
+		const { client, oauthClient } = await createTestInstance({
+			oauthProviderConfig: {
+				clientSecretPrefix: prefix,
+			},
+		});
+		expect(oauthClient?.client_secret?.startsWith(prefix)).toBeTruthy();
+
+		// Test successful utilization of client_secret
+		const tokens = await client.oauth2.token({
+			grant_type: "client_credentials",
+			client_id: oauthClient?.client_id,
+			client_secret: oauthClient?.client_secret,
+			scope: testScopes.join(""),
+		});
+		expect(tokens.error?.status).toBeUndefined();
+		expect(tokens.data?.access_token).toBeDefined();
+	});
+});

--- a/packages/better-auth/src/plugins/oauth-provider/token.test.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/token.test.ts
@@ -62,7 +62,7 @@ describe("oauth token - authorization_code", async () => {
 
 	// Registers a confidential client application to work with
 	beforeAll(async () => {
-		const response = await auth.api.registerOAuthClient({
+		const response = await auth.api.createOAuthClient({
 			headers,
 			body: {
 				redirect_uris: [redirectUri],
@@ -407,7 +407,7 @@ describe("oauth token - refresh_token", async () => {
 
 	// Registers a confidential client application to work with
 	beforeAll(async () => {
-		const response = await authorizationServer.api.registerOAuthClient({
+		const response = await authorizationServer.api.createOAuthClient({
 			headers,
 			body: {
 				redirect_uris: [redirectUri],
@@ -868,7 +868,7 @@ describe("oauth token - client_credentials", async () => {
 
 	// Registers a confidential client application to work with
 	beforeAll(async () => {
-		const response = await auth.api.registerOAuthClient({
+		const response = await auth.api.createOAuthClient({
 			headers,
 			body: {
 				redirect_uris: [redirectUri],
@@ -1062,7 +1062,7 @@ describe("oauth token - config", async () => {
 			},
 		});
 
-		const registeredClient = await auth.api.registerOAuthClient({
+		const registeredClient = await auth.api.createOAuthClient({
 			headers,
 			body: {
 				redirect_uris: [redirectUri],

--- a/packages/better-auth/src/plugins/oauth-provider/token.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/token.ts
@@ -1,0 +1,945 @@
+import { APIError } from "../../api";
+import type { GenericEndpointContext } from "@better-auth/core";
+import type { Session, User } from "../../types";
+import type {
+	SchemaClient,
+	OAuthOptions,
+	VerificationValue,
+	OAuthRefreshToken,
+} from "./types";
+import { createHash } from "@better-auth/utils/hash";
+import { generateRandomString } from "../../crypto";
+import {
+	basicToClientCredentials,
+	decryptStoredClientSecret,
+	getStoredToken,
+	getJwtPlugin,
+	storeToken,
+	validateClientCredentials,
+} from "./utils";
+import { userNormalClaims } from "./userinfo";
+import type { GrantType } from "../../oauth-2.1/types";
+import { SignJWT, type JWTPayload } from "jose";
+import { signJWT } from "../jwt/sign";
+import { toExpJWT } from "../jwt/utils";
+
+/**
+ * Handles the /oauth2/token endpoint by delegating
+ * the grant types
+ */
+export async function tokenEndpoint(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions,
+) {
+	let { body } = ctx;
+	if (!body) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "request body not found",
+			error: "invalid_request",
+		});
+	}
+	if (body instanceof FormData) {
+		body = Object.fromEntries(body.entries());
+	}
+
+	const grantType: GrantType | undefined = body?.grant_type;
+
+	if (opts.grantTypes && grantType && !opts.grantTypes.includes(grantType)) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: `unsupported grant_type ${grantType}`,
+			error: "unsupported_grant_type",
+		});
+	}
+
+	switch (grantType) {
+		case "authorization_code":
+			return handleAuthorizationCodeGrant(ctx, opts, body);
+		case "client_credentials":
+			return handleClientCredentialsGrant(ctx, opts, body);
+		case "refresh_token":
+			return handleRefreshTokenGrant(ctx, opts, body);
+		case undefined:
+			throw new APIError("BAD_REQUEST", {
+				error_description: "missing required grant_type",
+				error: "unsupported_grant_type",
+			});
+		default:
+			throw new APIError("BAD_REQUEST", {
+				error_description: `unsupported grant_type ${grantType}`,
+				error: "unsupported_grant_type",
+			});
+	}
+}
+
+// User Jwt SHALL follow oAuth 2
+// NOTE: Requires jwt plugin (assert !opts.disableJwtPlugin)
+async function createJwtAccessToken(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions,
+	user: User,
+	clientId: string,
+	audience: string | string[],
+	scopes: string[],
+	overrides?: {
+		iat?: number;
+		exp?: number;
+		sid?: string;
+	},
+) {
+	const iat = overrides?.iat ?? Math.floor(Date.now() / 1000);
+	const expiresIn = opts.accessTokenExpiresIn ?? 3600;
+	const exp = overrides?.exp ?? iat + expiresIn;
+	const customClaims = opts.customJwtClaims
+		? await opts.customJwtClaims(user, scopes)
+		: {};
+
+	const jwtPluginOptions = getJwtPlugin(ctx.context).options;
+
+	// Sign token
+	return signJWT(ctx, {
+		options: jwtPluginOptions,
+		payload: {
+			...customClaims,
+			sub: user.id.toString(),
+			aud:
+				typeof audience === "string"
+					? audience
+					: audience?.length === 1
+						? audience.at(0)
+						: audience,
+			azp: clientId,
+			scope: scopes.join(" "),
+			sid: overrides?.sid,
+			iss: jwtPluginOptions?.jwt?.issuer ?? ctx.context.baseURL,
+			iat,
+			exp,
+		},
+	});
+}
+
+/**
+ * Creates a user id token in code_authorization with scope of 'openid'
+ * and hybrid/implicit (not yet implemented) flows
+ */
+async function createIdToken(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions,
+	user: User,
+	clientId: string,
+	clientSecret: string | undefined,
+	scopes: string[],
+	nonce?: string,
+) {
+	const iat = Math.floor(Date.now() / 1000);
+	const expiresIn = 60 * 60 * 10; // 10 hour id token lifetime
+	const exp = iat + expiresIn;
+	const userClaims = userNormalClaims(user, scopes);
+	const authTime = Math.floor(
+		(ctx.context.session?.session.createdAt ?? new Date(iat * 1000)).getTime() /
+			1000,
+	);
+	// TODO: this should be validated against the login process
+	// - bronze : password only
+	// - silver : mfa
+	const acr = "urn:mace:incommon:iap:bronze";
+
+	const customClaims = opts.customIdTokenClaims
+		? await opts.customIdTokenClaims(user, scopes)
+		: {};
+
+	const jwtPluginOptions = opts.disableJwtPlugin
+		? undefined
+		: getJwtPlugin(ctx.context).options;
+
+	const payload: JWTPayload = {
+		...customClaims,
+		...userClaims,
+		auth_time: authTime,
+		acr,
+		iss: jwtPluginOptions?.jwt?.issuer ?? ctx.context.baseURL,
+		sub: user.id,
+		aud: clientId,
+		nonce,
+		iat,
+		exp,
+	};
+
+	// Public clients without a client secret cannot receive an idToken as it can't be verified
+	// Confidential clients would still receive an idToken signed by the clientSecret
+	if (opts.disableJwtPlugin && !clientSecret) {
+		return undefined;
+	}
+
+	return opts.disableJwtPlugin
+		? new SignJWT(payload)
+				.setProtectedHeader({ alg: "HS256" })
+				.sign(
+					new TextEncoder().encode(
+						await decryptStoredClientSecret(
+							ctx,
+							opts.storeClientSecret,
+							clientSecret!,
+						),
+					),
+				)
+		: signJWT(ctx, {
+				options: jwtPluginOptions,
+				payload,
+			});
+}
+
+/**
+ * Encodes a refresh token for a client
+ */
+async function encodeRefreshToken(
+	opts: OAuthOptions,
+	token: string,
+	sessionId?: string,
+) {
+	if (opts.encodeRefreshToken && !opts.decodeRefreshToken) {
+		throw new APIError("INTERNAL_SERVER_ERROR", {
+			message: "decodeRefreshToken should be defined",
+		});
+	}
+
+	return (
+		(opts.refreshTokenPrefix ?? "") +
+		(opts.encodeRefreshToken
+			? opts.encodeRefreshToken(token, sessionId)
+			: token)
+	);
+}
+
+/**
+ * Decodes a refresh token for a client
+ *
+ * @internal
+ */
+export async function decodeRefreshToken(opts: OAuthOptions, token: string) {
+	if (opts.refreshTokenPrefix) {
+		if (token.startsWith(opts.refreshTokenPrefix)) {
+			token = token.replace(opts.refreshTokenPrefix, "");
+		} else {
+			throw new APIError("BAD_REQUEST", {
+				error_description: "refresh token not found",
+				error: "invalid_token",
+			});
+		}
+	}
+
+	if (opts.decodeRefreshToken && !opts.encodeRefreshToken) {
+		throw new APIError("INTERNAL_SERVER_ERROR", {
+			message: "encodeRefreshToken should be defined",
+		});
+	}
+
+	return opts.decodeRefreshToken ? opts.decodeRefreshToken(token) : { token };
+}
+
+async function createOpaqueAccessToken(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions,
+	user: User | undefined,
+	clientId: string,
+	scopes: string[],
+	payload: JWTPayload,
+	refreshId?: string,
+) {
+	const iat = payload.iat ?? Math.floor(Date.now() / 1000);
+	const expiresIn = opts.accessTokenExpiresIn ?? 3600;
+	const exp = payload?.exp ?? iat + expiresIn;
+	const token = opts.generateOpaqueAccessToken
+		? await opts.generateOpaqueAccessToken()
+		: generateRandomString(32, "A-Z", "a-z");
+	await ctx.context.adapter.create({
+		model: opts.schema?.oauthAccessToken?.modelName ?? "oauthAccessToken",
+		data: {
+			token: await storeToken(opts.storeTokens, token, "access_token"),
+			clientId,
+			sessionId: payload?.sid,
+			userId: user?.id,
+			refreshId,
+			scopes: scopes.join(" "), // TODO: remove join when native arrays supported
+			createdAt: new Date(iat * 1000),
+			expiresAt: new Date(exp * 1000),
+		},
+	});
+	return (opts.opaqueAccessTokenPrefix ?? "") + token;
+}
+
+async function createRefreshToken(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions,
+	user: User,
+	clientId: string,
+	scopes: string[],
+	payload: JWTPayload,
+) {
+	const iat = payload.iat ?? Math.floor(Date.now() / 1000);
+	const exp = payload?.exp ?? iat + (opts.refreshTokenExpiresIn ?? 2592000);
+	const token = opts.generateRefreshToken
+		? await opts.generateRefreshToken()
+		: generateRandomString(32, "A-Z", "a-z");
+	const sessionId = payload?.sid as string | undefined;
+	const refreshToken = await ctx.context.adapter.create({
+		model: opts.schema?.oauthRefreshToken?.modelName ?? "oauthRefreshToken",
+		data: {
+			token: await storeToken(opts.storeTokens, token, "refresh_token"),
+			clientId,
+			sessionId,
+			userId: user.id,
+			scopes: scopes.join(" "), // TODO: remove join when native arrays supported
+			createdAt: new Date(iat * 1000),
+			expiresAt: new Date(exp * 1000),
+		},
+	});
+	return {
+		id: refreshToken.id,
+		token: await encodeRefreshToken(opts, token, sessionId),
+	};
+}
+
+/**
+ * Checks the resource parameter, if provided,
+ * and returns a valid audience based on the request
+ *
+ */
+async function checkResource(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions,
+	scopes: string[],
+) {
+	let _aud: string | string[] | undefined = ctx.body.resource;
+	const audience = typeof _aud === "string" ? [_aud] : _aud;
+	if (audience) {
+		// Adds /userinfo to audience
+		if (scopes.includes("openid")) {
+			audience.push(`${ctx.context.baseURL}/oauth2/userinfo`);
+		}
+		// Check valid audiences
+		const jwtPluginOptions = opts.disableJwtPlugin
+			? undefined
+			: getJwtPlugin(ctx.context).options;
+		const validAudiences = [
+			jwtPluginOptions?.jwt?.audience ?? ctx.context.baseURL,
+			scopes?.includes("openid")
+				? `${ctx.context.baseURL}/oauth2/userinfo`
+				: undefined,
+		]
+			.flat()
+			.filter((v) => v?.length);
+		for (const aud of audience) {
+			if (!validAudiences.includes(aud)) {
+				throw new APIError("BAD_REQUEST", {
+					error_description: "requested resource invalid",
+					error: "invalid_request",
+				});
+			}
+		}
+	}
+	return audience?.length === 1 ? audience.at(0) : audience;
+}
+
+async function createUserTokens(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions,
+	client: SchemaClient,
+	scopes: string[],
+	user: User,
+	sessionId?: string,
+	nonce?: string,
+) {
+	const iat = Math.floor(Date.now() / 1000);
+	const defaultExp = iat + (opts.accessTokenExpiresIn ?? 3600);
+	const exp = opts.scopeExpirations
+		? scopes
+				.map((sc) =>
+					opts.scopeExpirations?.[sc]
+						? toExpJWT(opts.scopeExpirations[sc], iat)
+						: defaultExp,
+				)
+				.reduce((prev, curr) => {
+					return prev < curr ? prev : curr;
+				}, defaultExp)
+		: defaultExp;
+
+	// Check requested audience if sent as the resource parameter
+	const audience = await checkResource(ctx, opts, scopes);
+	const isRefreshToken = scopes.includes("offline_access");
+	const isJwtAccessToken = audience && !opts.disableJwtPlugin;
+	const isIdToken = scopes.includes("openid");
+
+	// Refresh token may need to be created beforehand for id field
+	const earlyRefreshToken =
+		isRefreshToken && !isJwtAccessToken
+			? await createRefreshToken(ctx, opts, user, client.clientId, scopes, {
+					iat,
+					exp: iat + (opts.refreshTokenExpiresIn ?? 2592000),
+					sid: sessionId,
+				})
+			: undefined;
+
+	// Sign jwt and refresh tokens in parallel
+	const [accessToken, refreshToken, idToken] = await Promise.all([
+		isJwtAccessToken
+			? createJwtAccessToken(
+					ctx,
+					opts,
+					user,
+					client.clientId,
+					audience,
+					scopes,
+					{
+						iat,
+						exp,
+						sid: sessionId,
+					},
+				)
+			: createOpaqueAccessToken(
+					ctx,
+					opts,
+					user,
+					client.clientId,
+					scopes,
+					{
+						iat,
+						exp,
+						sid: sessionId,
+					},
+					earlyRefreshToken?.id,
+				),
+		earlyRefreshToken
+			? earlyRefreshToken
+			: isRefreshToken
+				? createRefreshToken(ctx, opts, user, client.clientId, scopes, {
+						iat,
+						exp: iat + (opts.refreshTokenExpiresIn ?? 2592000),
+						sid: sessionId,
+					})
+				: undefined,
+		isIdToken
+			? createIdToken(
+					ctx,
+					opts,
+					user,
+					client.clientId,
+					client.clientSecret,
+					scopes,
+					nonce,
+				)
+			: undefined,
+	]);
+
+	return ctx.json(
+		{
+			access_token: accessToken,
+			expires_in: exp - iat,
+			expires_at: exp,
+			token_type: "Bearer",
+			refresh_token: refreshToken?.token,
+			scope: scopes.join(" "),
+			id_token: idToken,
+		},
+		{
+			headers: {
+				"Cache-Control": "no-store",
+				Pragma: "no-cache",
+			},
+		},
+	);
+}
+
+/** Checks verification value */
+async function checkVerificationValue(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions,
+	code: string,
+	client_id: string,
+	redirect_uri?: string,
+) {
+	const verification = await ctx.context.internalAdapter.findVerificationValue(
+		await storeToken(opts.storeTokens, code, "authorization_code"),
+	);
+	const verificationValue: VerificationValue = verification
+		? JSON.parse(verification?.value)
+		: undefined;
+
+	if (!verification) {
+		throw new APIError("UNAUTHORIZED", {
+			error_description: "Invalid code",
+			error: "invalid_verification",
+		});
+	}
+
+	// Delete used code
+	if (verification?.id) {
+		await ctx.context.internalAdapter.deleteVerificationValue(verification.id);
+	}
+
+	// Check verification
+	if (!verification.expiresAt || verification.expiresAt < new Date()) {
+		throw new APIError("UNAUTHORIZED", {
+			error_description: "code expired",
+			error: "invalid_verification",
+		});
+	}
+
+	// Check verification value
+	if (!verificationValue) {
+		throw new APIError("UNAUTHORIZED", {
+			error_description: "missing verification value content",
+			error: "invalid_verification",
+		});
+	}
+	if (verificationValue.type !== "authorization_code") {
+		throw new APIError("UNAUTHORIZED", {
+			error_description: "incorrect verification type",
+			error: "invalid_verification",
+		});
+	}
+	if (verificationValue.clientId !== client_id) {
+		throw new APIError("UNAUTHORIZED", {
+			error_description: "invalid client_id",
+			error: "invalid_client",
+		});
+	}
+	if (!verificationValue.userId) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "missing user_id on challenge",
+			error: "invalid_user",
+		});
+	}
+	if (
+		verificationValue.redirectUri &&
+		verificationValue.redirectUri != redirect_uri
+	) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "missing verification redirect_uri",
+			error: "invalid_request",
+		});
+	}
+
+	return verificationValue;
+}
+
+/**
+ * Obtains new Session Jwt and Refresh Tokens using a code
+ */
+async function handleAuthorizationCodeGrant(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions,
+	body: any,
+) {
+	let {
+		client_id,
+		client_secret,
+		code,
+		code_verifier,
+		redirect_uri,
+	}: {
+		client_id?: string;
+		client_secret?: string;
+		code?: string;
+		code_verifier?: string;
+		redirect_uri?: string;
+	} = body;
+	const authorization = ctx.request?.headers.get("authorization") || null;
+
+	// Convert basic authorization
+	if (authorization?.startsWith("Basic ")) {
+		const res = basicToClientCredentials(authorization);
+		client_id = res?.client_id;
+		client_secret = res?.client_secret;
+	}
+
+	if (!client_id) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "client_id is required",
+			error: "invalid_request",
+		});
+	}
+	if (!code) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "code is required",
+			error: "invalid_request",
+		});
+	}
+	if (!redirect_uri) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "redirect_uri is required",
+			error: "invalid_request",
+		});
+	}
+
+	const isAuthCodeWithSecret = client_id && client_secret;
+	const isAuthCodeWithPkce = client_id && code && code_verifier;
+
+	if (!(isAuthCodeWithPkce || isAuthCodeWithSecret)) {
+		throw new APIError("BAD_REQUEST", {
+			error_description:
+				"Missing a required credential value for authorization_code grant",
+			error: "invalid_request",
+		});
+	}
+
+	/** Get and check Verification Value */
+	const verificationValue = await checkVerificationValue(
+		ctx,
+		opts,
+		code,
+		client_id,
+		redirect_uri,
+	);
+	const scopes = verificationValue.scopes?.split(" ");
+
+	/** Verify Client */
+	const client = await validateClientCredentials(
+		ctx,
+		opts,
+		client_id,
+		client_secret,
+		scopes,
+	);
+
+	/** Check challenge */
+	const challenge =
+		code_verifier && verificationValue.codeChallengeMethod === "S256"
+			? await createHash("SHA-256", "base64urlnopad").digest(code_verifier)
+			: undefined;
+	if (
+		// AuthCodeWithSecret - Required if sent
+		isAuthCodeWithSecret &&
+		(challenge || verificationValue?.codeChallenge) &&
+		challenge !== verificationValue.codeChallenge
+	) {
+		throw new APIError("UNAUTHORIZED", {
+			error_description: "code verification failed",
+			error: "invalid_request",
+		});
+	}
+	if (
+		// AuthCodeWithPkce - Always required
+		isAuthCodeWithPkce &&
+		challenge !== verificationValue.codeChallenge
+	) {
+		throw new APIError("UNAUTHORIZED", {
+			error_description: "code verification failed",
+			error: "invalid_request",
+		});
+	}
+
+	/** Get user */
+	if (!verificationValue.userId) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "missing user, user may have been deleted",
+			error: "invalid_user",
+		});
+	}
+	const user = await ctx.context.internalAdapter.findUserById(
+		verificationValue.userId,
+	);
+	if (!user) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "missing user, user may have been deleted",
+			error: "invalid_user",
+		});
+	}
+
+	// Check if session used is still active
+	const session = await ctx.context.adapter.findOne<Session>({
+		model: "session",
+		where: [
+			{
+				field: "id",
+				value: verificationValue.sessionId,
+			},
+		],
+	});
+	if (!session || session.expiresAt < new Date()) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "session no longer exists",
+			error: "invalid_request",
+		});
+	}
+
+	return createUserTokens(
+		ctx,
+		opts,
+		client,
+		verificationValue.scopes?.split(" ") ?? [],
+		user,
+		session.id,
+		verificationValue.nonce,
+	);
+}
+
+/**
+ * Grant that allows direct access to an API using the application's credentials
+ * This grant is for M2M so the concept of a user id does not exist on the token.
+ *
+ * MUST follow https://datatracker.ietf.org/doc/html/rfc6749#section-4.4
+ */
+async function handleClientCredentialsGrant(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions,
+	body: any,
+) {
+	let {
+		client_id,
+		client_secret,
+		scope,
+	}: {
+		client_id?: string;
+		client_secret?: string;
+		scope?: string;
+	} = body;
+	const authorization = ctx.request?.headers.get("authorization") || null;
+
+	// Convert basic authorization
+	if (authorization?.startsWith("Basic ")) {
+		const res = basicToClientCredentials(authorization);
+		client_id = res?.client_id;
+		client_secret = res?.client_secret;
+	}
+
+	if (!client_id) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "Missing required client_id",
+			error: "invalid_grant",
+		});
+	}
+	if (!client_secret) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "Missing a required client_secret",
+			error: "invalid_grant",
+		});
+	}
+	if (!scope) scope = opts.clientCredentialGrantDefaultScopes?.join(" ");
+	if (!scope) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "Missing required scope",
+			error: "invalid_scope",
+		});
+	}
+
+	// OIDC scopes should not be requestable (code authorization grant should be used)
+	const requestedScopes = scope.split(" ");
+	const invalidScopes = ["openid", "profile", "email", "offline_access"];
+	for (const sc of requestedScopes) {
+		if (invalidScopes.includes(sc)) {
+			throw new APIError("BAD_REQUEST", {
+				error_description: `unable to satisfy scope ${sc}`,
+				error: "invalid_scope",
+			});
+		}
+		if (opts.scopes && !opts.scopes.includes(sc)) {
+			throw new APIError("BAD_REQUEST", {
+				error_description: `invalid scope ${sc}`,
+				error: "invalid_scope",
+			});
+		}
+	}
+
+	// Check requested audience if sent as the resource parameter
+	const jwtPluginOptions = opts.disableJwtPlugin
+		? undefined
+		: getJwtPlugin(ctx.context).options;
+	const audience = await checkResource(ctx, opts, requestedScopes);
+
+	await validateClientCredentials(
+		ctx,
+		opts,
+		client_id,
+		client_secret,
+		requestedScopes,
+	);
+
+	const iat = Math.floor(Date.now() / 1000);
+	const defaultExp = iat + (opts.m2mAccessTokenExpiresIn ?? 3600);
+	const exp = opts.scopeExpirations
+		? requestedScopes
+				.map((sc) =>
+					opts.scopeExpirations?.[sc]
+						? toExpJWT(opts.scopeExpirations[sc], iat)
+						: defaultExp,
+				)
+				.reduce((prev, curr) => {
+					return prev < curr ? prev : curr;
+				}, defaultExp)
+		: defaultExp;
+
+	const accessToken =
+		audience && !opts.disableJwtPlugin
+			? await signJWT(ctx, {
+					options: jwtPluginOptions,
+					payload: {
+						aud: audience,
+						azp: client_id,
+						scope: requestedScopes.join(" "),
+						iss: jwtPluginOptions?.jwt?.issuer ?? ctx.context.baseURL,
+						iat,
+						exp,
+					},
+				})
+			: await createOpaqueAccessToken(
+					ctx,
+					opts,
+					undefined,
+					client_id,
+					requestedScopes,
+					{
+						iat,
+						exp,
+					},
+				);
+
+	return ctx.json(
+		{
+			access_token: accessToken,
+			expires_in: exp - iat,
+			expires_at: exp,
+			token_type: "Bearer",
+			scope: requestedScopes.join(" "),
+		},
+		{
+			headers: {
+				"Cache-Control": "no-store",
+				Pragma: "no-cache",
+			},
+		},
+	);
+}
+
+/**
+ * Obtains new Session Jwt and Refresh Tokens using a refresh token
+ *
+ * Refresh tokens will only allow the same or lesser scopes as the initial authorize request.
+ * To add scopes, you must restart the authorize process again.
+ */
+async function handleRefreshTokenGrant(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions,
+	body: any,
+) {
+	let {
+		client_id,
+		client_secret,
+		refresh_token,
+		scope,
+	}: {
+		client_id?: string;
+		client_secret?: string;
+		refresh_token?: string;
+		scope?: string;
+	} = body;
+
+	const authorization = ctx.request?.headers.get("authorization") || null;
+
+	// Convert basic authorization
+	if (authorization?.startsWith("Basic ")) {
+		const res = basicToClientCredentials(authorization);
+		client_id = res?.client_id;
+		client_secret = res?.client_secret;
+	}
+
+	if (!client_id) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "Missing required client_id",
+			error: "invalid_grant",
+		});
+	}
+
+	if (!refresh_token) {
+		throw new APIError("BAD_REQUEST", {
+			error_description:
+				"Missing a required refresh_token for refresh_token grant",
+			error: "invalid_grant",
+		});
+	}
+	const decodedRefresh = await decodeRefreshToken(opts, refresh_token);
+
+	const refreshToken = await ctx.context.adapter
+		.findOne<OAuthRefreshToken>({
+			model: "oauthRefreshToken",
+			where: [
+				{
+					field: "token",
+					value: await getStoredToken(
+						opts.storeTokens,
+						decodedRefresh.token,
+						"refresh_token",
+					),
+				},
+			],
+		})
+		.then((res) => {
+			// TODO: remove when native arrays supported
+			if (!res) return res;
+			return {
+				...res,
+				scopes: (res?.scopes as unknown as string)?.split(" "),
+			} as OAuthRefreshToken;
+		});
+
+	// Check session
+	if (!refreshToken) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "session not found",
+			error: "invalid_request",
+		});
+	}
+	if (refreshToken.clientId !== client_id?.toString()) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "invalid client_id",
+			error: "invalid_client",
+		});
+	}
+	if (refreshToken.expiresAt < new Date()) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "refresh token expired",
+			error: "invalid_request",
+		});
+	}
+
+	// Check session scopes
+	const scopes = refreshToken?.scopes ?? [];
+	const requestedScopes = scope?.split(" ");
+	if (requestedScopes) {
+		for (const requestedScope of requestedScopes) {
+			if (!scopes?.includes(requestedScope)) {
+				throw new APIError("BAD_REQUEST", {
+					error_description: `unable to issue scope ${requestedScope}`,
+					error: "invalid_scope",
+				});
+			}
+		}
+	}
+
+	const client = await validateClientCredentials(
+		ctx,
+		opts,
+		client_id,
+		client_secret, // Optional for refresh_grant but required on confidential clients
+		requestedScopes ?? scopes,
+	);
+
+	const user = await ctx.context.internalAdapter.findUserById(
+		refreshToken.userId,
+	);
+	if (!user) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "user not found",
+			error: "invalid_request",
+		});
+	}
+
+	// Generate new tokens
+	return createUserTokens(
+		ctx,
+		opts,
+		client,
+		requestedScopes ?? scopes,
+		user,
+		refreshToken.sessionId,
+	);
+}

--- a/packages/better-auth/src/plugins/oauth-provider/token.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/token.ts
@@ -90,7 +90,10 @@ async function createJwtAccessToken(
 	const expiresIn = opts.accessTokenExpiresIn ?? 3600;
 	const exp = overrides?.exp ?? iat + expiresIn;
 	const customClaims = opts.customJwtClaims
-		? await opts.customJwtClaims(user, scopes)
+		? await opts.customJwtClaims(user, scopes, {
+				sessionId: overrides?.sid,
+				clientId: clientId,
+			})
 		: {};
 
 	const jwtPluginOptions = getJwtPlugin(ctx.context).options;
@@ -129,6 +132,7 @@ async function createIdToken(
 	clientSecret: string | undefined,
 	scopes: string[],
 	nonce?: string,
+	sessionId?: string,
 ) {
 	const iat = Math.floor(Date.now() / 1000);
 	const expiresIn = 60 * 60 * 10; // 10 hour id token lifetime
@@ -144,7 +148,10 @@ async function createIdToken(
 	const acr = "urn:mace:incommon:iap:bronze";
 
 	const customClaims = opts.customIdTokenClaims
-		? await opts.customIdTokenClaims(user, scopes)
+		? await opts.customIdTokenClaims(user, scopes, {
+				sessionId: sessionId,
+				clientId: clientId,
+			})
 		: {};
 
 	const jwtPluginOptions = opts.disableJwtPlugin
@@ -426,6 +433,7 @@ async function createUserTokens(
 					client.clientSecret,
 					scopes,
 					nonce,
+					sessionId,
 				)
 			: undefined,
 	]);

--- a/packages/better-auth/src/plugins/oauth-provider/types.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/types.ts
@@ -1,0 +1,709 @@
+import type { GrantType } from "../../oauth-2.1/types";
+import type { InferOptionSchema, User } from "../../types";
+import type { Awaitable } from "../../types/helper";
+import { schema } from "./schema";
+
+export type StoreTokenType =
+	| "access_token"
+	| "refresh_token"
+	| "authorization_code";
+
+export interface OAuthOptions {
+	/**
+	 * Custom schema definitions
+	 */
+	schema?: InferOptionSchema<typeof schema>;
+	/**
+	 * Trusted clients that are configured directly in the provider options.
+	 * These clients bypass database lookups and can optionally skip consent screens.
+	 */
+	trustedClients?: SchemaClient[];
+	/**
+	 * The amount of time in seconds that the access token is valid for.
+	 *
+	 * @default 3600 (1 hour) - Industry standard
+	 */
+	accessTokenExpiresIn?: number;
+	/**
+	 * The amount of time in seconds that a client
+	 * credentials grant access token is valid for.
+	 *
+	 * @default 3600 (1 hour)
+	 */
+	m2mAccessTokenExpiresIn?: number;
+	/**
+	 * The amount of time in seconds that id token is valid for.
+	 *
+	 * @default 36000 (10 hours) - Recommended by the OIDC spec
+	 */
+	idTokenExpiresIn?: number;
+	/**
+	 * The amount of time in seconds that the refresh token is valid for.
+	 * Typical industry standard is 30 days
+	 *
+	 * @default 2592000 (30 days)
+	 */
+	refreshTokenExpiresIn?: number;
+	/**
+	 * The amount of time in seconds that the authorization code is valid for.
+	 *
+	 * @default 600 (10 minutes) - Recommended by the OIDC spec
+	 */
+	codeExpiresIn?: number;
+	/**
+	 * Allow unauthenticated dynamic client registration.
+	 *
+	 * @default false
+	 */
+	allowUnauthenticatedClientRegistration?: boolean;
+	/**
+	 * Allow dynamic client registration.
+	 *
+	 * @default false
+	 */
+	allowDynamicClientRegistration?: boolean;
+	/**
+	 * List of scopes for newly registered clients
+	 * if not requested.
+	 *
+	 * @default undefined
+	 */
+	clientRegistrationDefaultScopes?: string[];
+	/**
+	 * List of scopes for allowed clients in addition to
+	 * those listed in the default scope. Finalized allowed list is
+	 * the union of the default scopes and this list.
+	 *
+	 * If both clientRegistrationDefaultScopes and this
+	 * are undefined, only scopes listed in the scopes option
+	 * are allowed.
+	 *
+	 * @default - clientRegistrationDefaultScopes
+	 */
+	clientRegistrationAllowedScopes?: string[];
+	/**
+	 * How long a dynamically created confidential client
+	 * should last for.
+	 *
+	 * - If a `number` is passed as an argument it is used as the claim directly.
+	 * - If a `Date` instance is passed as an argument it is converted to unix timestamp and used as the
+	 *   claim.
+	 * - If a `string` is passed as an argument it is resolved to a time span, and then added to the
+	 *   current unix timestamp and used as the claim.
+	 *
+	 * Format used for time span should be a number followed by a unit, such as "5 minutes" or "1
+	 * day".
+	 *
+	 * Valid units are: "sec", "secs", "second", "seconds", "s", "minute", "minutes", "min", "mins",
+	 * "m", "hour", "hours", "hr", "hrs", "h", "day", "days", "d", "week", "weeks", "w", "year",
+	 * "years", "yr", "yrs", and "y". It is not possible to specify months. 365.25 days is used as an
+	 * alias for a year.
+	 *
+	 * If the string is suffixed with "ago", or prefixed with a "-", the resulting time span gets
+	 * subtracted from the current unix timestamp. A "from now" suffix can also be used for
+	 * readability when adding to the current unix timestamp.
+	 *
+	 * @default - undefined (does not expire)
+	 */
+	clientRegistrationClientSecretExpiration?: number | string | Date;
+	/**
+	 * List of scopes a newly registered client can have.
+	 *
+	 * Leave undefined to throw error if no scope was sent
+	 *
+	 * @default undefined
+	 */
+	clientCredentialGrantDefaultScopes?: string[];
+	/**
+	 * The scopes that the client is allowed to request.
+	 * Must contain "openid" to be considered an OIDC server,
+	 * otherwise it is just an OAuth server.
+	 *
+	 * @see https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims
+	 * @default
+	 * ```ts
+	 * ["openid", "profile", "email", "offline_access"]
+	 * ```
+	 */
+	scopes?: string[];
+	/**
+	 * Grant types supported by the token endpoint
+	 *
+	 * @default
+	 * ["authorization_code", "client_credentials", "refresh_token"]
+	 */
+	grantTypes?: GrantType[];
+	/**
+	 * Create access token expirations based on scope.
+	 *
+	 * This is useful for higher-privelege scopes that
+	 * require shorter expiration times. The earliest
+	 * expiration will take precendence. If not specified,
+	 * the default will take place.
+	 *
+	 * Note: values should be lower than the defaults
+	 * `accessTokenExpiresIn` and `m2mAccessTokenExpiresIn`
+	 *
+	 * @example
+	 * { "write:payments": "5m", "read:payments": "30m" }
+	 */
+	scopeExpirations?: Record<string, number | string | Date>;
+	/**
+	 * The URL to the login page. This is used if the client requests the `login`
+	 * prompt.
+	 */
+	loginPage: string;
+	/**
+	 * A URL to the consent page where the user will be redirected if the client
+	 * requests consent.
+	 *
+	 * After the user consents, they should be redirected by the client to the
+	 * `redirect_uri` with the authorization code.
+	 *
+	 * When the server redirects the user to the consent page, it will include the
+	 * following query parameters:
+	 *
+	 * - `client_id` - The ID of the client.
+	 * - `scope` - The requested scopes.
+	 * - `code` - The authorization code.
+	 *
+	 * once the user consents, you need to call the `/oauth2/consent` endpoint
+	 * with the code and `accept: true` to complete the authorization. Which will
+	 * then return the client to the `redirect_uri` with the authorization code.
+	 *
+	 * @example
+	 * ```ts
+	 * consentPage: "/consent"
+	 * ```
+	 */
+	consentPage: string;
+	/**
+	 * Custom function to generate a client ID.
+	 */
+	generateClientId?: () => string;
+	/**
+	 * Custom function to generate a client secret.
+	 */
+	generateClientSecret?: () => string;
+	/**
+	 * Store the client secret in your database in a secure way
+	 * Note: This will not affect the client secret sent to the user, it will only affect the client secret stored in your database
+	 *
+	 * When disableJwtPlugin = false (recommended):
+	 * - "hashed" - The client secret is hashed using the `hash` function.
+	 * - { hash: (clientSecret: string) => Promise<string> } - A function that hashes the client secret.
+	 *
+	 * When disableJwtPlugin = true:
+	 * - "encrypted" - The client secret is encrypted using the `encrypt` function.
+	 * - { encrypt: (clientSecret: string) => Promise<string>, decrypt: (clientSecret: string) => Promise<string> } - A function that encrypts and decrypts the client secret.
+	 *
+	 * @default
+	 * options.disableJwtPlugin ? "encrypted" : "hashed"
+	 */
+	storeClientSecret?:
+		| "hashed"
+		| "encrypted"
+		| { hash: (clientSecret: string) => Promise<string> }
+		| {
+				encrypt: (clientSecret: string) => Promise<string>;
+				decrypt: (clientSecret: string) => Promise<string>;
+		  };
+	/**
+	 * Storage method of opaque access tokens and refresh tokens on your database.
+	 *
+	 * - "hashed" - The client secret is hashed using the `hash` function.
+	 * - { hash: (token: string, type: StoreTokenType) => Promise<string> } - A function that hashes the token
+	 *
+	 * @default "hashed"
+	 */
+	storeTokens?:
+		| "hashed"
+		| { hash: (token: string, type: StoreTokenType) => Promise<string> };
+	/**
+	 * Get the additional user info claims
+	 *
+	 * This applies only to the OIDC `userinfo` endpoint.
+	 *
+	 * @param user - The user object.
+	 * @param scopes - The scopes that the client requested.
+	 * @returns The user info claim.
+	 */
+	getAdditionalUserInfoClaim?: (
+		user: User & Record<string, any>,
+		scopes: string[],
+	) => Awaitable<Record<string, any>>;
+	/**
+	 * List of all additional claims returned from
+	 * customIdTokenClaims and customJwtClaims.
+	 *
+	 * Must be defined when using
+	 * customIdTokenClaims or customJwtClaims
+	 */
+	customClaims?: string[];
+	/**
+	 * Custom claims attached to id tokens.
+	 * To remain OIDC compliant, claims should be
+	 * namespaced with a URI. For example, a site
+	 * example.com should namespace roles at
+	 * https://example.com/roles.
+	 */
+	customIdTokenClaims?: (
+		user: User,
+		scopes: string[],
+	) => Awaitable<Record<string, any>>;
+	/**
+	 * Custom claims attached to access tokens.
+	 */
+	customJwtClaims?: (
+		user: User,
+		scopes: string[],
+	) => Awaitable<Record<string, any>>;
+	/**
+	 * Overwrite specific /.well-known/openid-configuration
+	 * values so they are not available publically.
+	 * This may be important if not all clients need specific scopes.
+	 *
+	 * NOTE: this does not prevent the system from issuing
+	 * these scopes and returning those claims (use scopes and customClaims instead).
+	 */
+	advertisedMetadata?: {
+		/**
+		 * Advertised scopes_supported located at /.well-known/openid-configuration
+		 *
+		 * All values must be found in the scope field
+		 */
+		scopes_supported?: string[];
+		/**
+		 * Advertised claims_supported located at /.well-known/openid-configuration
+		 *
+		 * All values must be found in the customClaims field or
+		 * be an internally supported claim.
+		 *
+		 * Internally supported claims:
+		 * ["sub", "iss", "aud", "exp", "iat", "sid", "scope", "azp"]
+		 */
+		claims_supported?: string[];
+	};
+	/**
+	 * Adds a prefix to an opaque access token.
+	 * Note: the prefix is not stored in the database.
+	 *
+	 * Useful when also using the [API Key Plugin](../api-key/index.ts)
+	 * or Secret Scanners (ie Github Secret Scanning, GitGuardian, Trufflehog).
+	 *
+	 * We recommend to append an underscore to make it more identifiable
+	 * Additionally, we recommend you add the prefix prior to the first deployment
+	 * otherwise you must utilize this with generateOpaqueAccessToken (storing the full
+	 * encoded value on the database).
+	 *
+	 * @example "domain_at_"
+	 * @default undefined
+	 */
+	opaqueAccessTokenPrefix?: string;
+	/**
+	 * Adds a prefix to an opaque refresh token.
+	 * Note: the prefix is not stored in the database.
+	 *
+	 * Useful when using Secret Scanners (ie Github Secret Scanning,
+	 * GitGuardian, Trufflehog).
+	 *
+	 * We recommend to append an underscore to make it more identifiable
+	 * Additionally, we recommend you add the prefix prior to the first deployment
+	 * otherwise you must utilize this with generateRefreshToken (storing the full
+	 * encoded value on the database).
+	 *
+	 * @example "domain_rt_"
+	 * @default undefined
+	 */
+	refreshTokenPrefix?: string;
+	/**
+	 * Adds a prefix to delivered client secrets.
+	 * Note: the prefix is not stored in the database.
+	 *
+	 * Useful when using Secret Scanners (ie Github Secret Scanning,
+	 * GitGuardian, Trufflehog).
+	 *
+	 * We recommend to append an underscore to make it more identifiable.
+	 * Additionally, we recommend you add the prefix prior to the first deployment
+	 * otherwise you must utilize this with generateClientSecret (storing the full
+	 * encoded value on the database).
+	 *
+	 * @example "domain_cs_"
+	 * @default undefined
+	 */
+	clientSecretPrefix?: string;
+	/**
+	 * Generate a unique access token to save on the database.
+	 *
+	 * @default
+	 * generateRandomString(32, "A-Z", "a-z")
+	 */
+	generateOpaqueAccessToken?: () => Awaitable<string>;
+	/**
+	 * Generate a unique refresh token to save on the database.
+	 *
+	 * @default
+	 * generateRandomString(32, "A-Z", "a-z")
+	 */
+	generateRefreshToken?: () => Awaitable<string>;
+	/**
+	 * Custom session token formatter. You can
+	 * choose to perform additional functionality such as
+	 * refresh token encryption or store the raw token
+	 * for session replay attacks.
+	 *
+	 * If defined, you must provide the function
+	 * decodeRefreshToken.
+	 */
+	encodeRefreshToken?: (token: string, sessionId?: string) => Awaitable<string>;
+	/**
+	 * Decodes a custom session token format.
+	 * If you changed the format after production deployment,
+	 * ensure that the prior version can still be decoded.
+	 *
+	 * Must be defined when using encodeRefreshToken.
+	 *
+	 * @returns {string | undefined} sessionId - if returned,
+	 * should be same as the one received in encodeRefreshToken.
+	 * There is an added benefit that updates to the session occur
+	 * via id instead of token.
+	 * @returns {string} token - should be same as the one
+	 * received in encodeRefreshToken
+	 */
+	decodeRefreshToken?: (
+		token: string,
+	) => Awaitable<{ sessionId?: string; token: string }>;
+	/**
+	 * Confirmations that individually silences specific well-known endpoint
+	 * configuration warnings.
+	 *
+	 * Only set these specific values if you see the error as they
+	 * are configuration specific.
+	 */
+	silenceWarnings?: {
+		/**
+		 * Config warning for `/.well-known/oauth-authorization-server/[issuer-path]`
+		 *
+		 * @default false
+		 */
+		oauthAuthServerConfig?: boolean;
+		/**
+		 * Config warning for `[issuer-path]/.well-known/openid-configuration`
+		 *
+		 * @default false
+		 */
+		openidConfig?: boolean;
+	};
+	/**
+	 * By default, access and id tokens can be issued and verified
+	 * through the JWT plugin.
+	 *
+	 * You can disable the JWT requirement in which access tokens
+	 * will always be opaque and id tokens are always signed
+	 * with HS256 using the client secret.
+	 *
+	 * @default false
+	 */
+	disableJwtPlugin?: boolean;
+}
+
+export interface OAuthAuthorizationQuery {
+	/**
+	 * The response type.
+	 * - "code": authorization code flow.
+	 */
+	// NEVER SUPPORT "token" or "id_token" - depreciated in oAuth2.1
+	response_type: "code";
+	/**
+	 * The redirect URI for the client. Must be one of the registered redirect URLs for the client.
+	 */
+	redirect_uri: string;
+	/**
+	 * The scope of the request. Must be a space-separated list of case sensitive strings.
+	 *
+	 * - "openid" is required for all requests
+	 * - "profile" is required for requests that require user profile information.
+	 * - "email" is required for requests that require user email information.
+	 * - "offline_access" is required for requests that require a refresh token.
+	 */
+	scope?: string;
+	/**
+	 * Opaque value used to maintain state between the request and the callback. Typically,
+	 * Cross-Site Request Forgery (CSRF, XSRF) mitigation is done by cryptographically binding the
+	 * value of this parameter with a browser cookie.
+	 *
+	 * Note: Better Auth stores the state in a database instead of a cookie. - This is to minimize
+	 * the complication with native apps and other clients that may not have access to cookies.
+	 */
+	state: string;
+	/**
+	 * The client ID. Must be the ID of a registered client.
+	 */
+	client_id: string;
+	/**
+	 * The prompt parameter is used to specify the type of user interaction that is required.
+	 */
+	prompt?: "none" | "consent" | "login" | "select_account";
+	/**
+	 * The display parameter is used to specify how the authorization server displays the
+	 * authentication and consent user interface pages to the end user.
+	 */
+	display?: "page" | "popup" | "touch" | "wap";
+	/**
+	 * End-User's preferred languages and scripts for the user interface, represented as a
+	 * space-separated list of BCP47 [RFC5646] language tag values, ordered by preference. For
+	 * instance, the value "fr-CA fr en" represents a preference for French as spoken in Canada,
+	 * then French (without a region designation), followed by English (without a region
+	 * designation).
+	 *
+	 * Better Auth does not support this parameter yet. It'll not throw an error if it's provided,
+	 *
+	 * 🏗️ currently not implemented
+	 */
+	ui_locales?: string;
+	/**
+	 * The maximum authentication age.
+	 *
+	 * Specifies the allowable elapsed time in seconds since the last time the End-User was
+	 * actively authenticated by the provider. If the elapsed time is greater than this value, the
+	 * provider MUST attempt to actively re-authenticate the End-User.
+	 *
+	 * Note that max_age=0 is equivalent to prompt=login.
+	 */
+	max_age?: number;
+	/**
+	 * Requested Authentication Context Class Reference values.
+	 *
+	 * Space-separated string that
+	 * specifies the acr values that the Authorization Server is being requested to use for
+	 * processing this Authentication Request, with the values appearing in order of preference.
+	 * The Authentication Context Class satisfied by the authentication performed is returned as
+	 * the acr Claim Value, as specified in Section 2. The acr Claim is requested as a Voluntary
+	 * Claim by this parameter.
+	 */
+	acr_values?: string;
+	/**
+	 * Hint to the Authorization Server about the login identifier the End-User might use to log in
+	 * (if necessary). This hint can be used by an RP if it first asks the End-User for their
+	 * e-mail address (or other identifier) and then wants to pass that value as a hint to the
+	 * discovered authorization service. It is RECOMMENDED that the hint value match the value used
+	 * for discovery. This value MAY also be a phone number in the format specified for the
+	 * phone_number Claim. The use of this parameter is left to the OP's discretion.
+	 */
+	login_hint?: string;
+	/**
+	 * ID Token previously issued by the Authorization Server being passed as a hint about the
+	 * End-User's current or past authenticated session with the Client.
+	 *
+	 * 🏗️ currently not implemented
+	 */
+	id_token_hint?: string;
+	/**
+	 * Code challenge
+	 */
+	code_challenge?: string;
+	/**
+	 * Code challenge method used
+	 */
+	code_challenge_method?: "S256";
+	/**
+	 * String value used to associate a Client session with an ID Token, and to mitigate replay
+	 * attacks. The value is passed through unmodified from the Authentication Request to the ID Token.
+	 * If present in the ID Token, Clients MUST verify that the nonce Claim Value is equal to the
+	 * value of the nonce parameter sent in the Authentication Request. If present in the
+	 * Authentication Request, Authorization Servers MUST include a nonce Claim in the ID Token
+	 * with the Claim Value being the nonce value sent in the Authentication Request.
+	 */
+	nonce?: string;
+}
+
+/**
+ * Stored within the verification.value field
+ * in JSON format.
+ *
+ * It is stored in JSON to prevent
+ * direct searches by field on the db
+ */
+export interface VerificationValue {
+	type: "authorization_code" | "consent";
+	clientId: string;
+	sessionId: string;
+	userId: string;
+	redirectUri?: string;
+	scopes: string;
+	state?: string;
+	codeChallenge?: string;
+	codeChallengeMethod?: "S256";
+	nonce?: string;
+}
+
+/**
+ * Client registered values as used within the plugin
+ */
+export interface SchemaClient {
+	//---- Required ----//
+	/**
+	 * Client ID
+	 *
+	 * size 32
+	 *
+	 * as described on https://www.rfc-editor.org/rfc/rfc6749.html#section-2.2
+	 */
+	clientId: string;
+	/**
+	 * Client Secret
+	 *
+	 * A secret for the client, if required by the authorization server.
+	 *
+	 * size 32
+	 */
+	clientSecret?: string;
+	/** Whether the client is disabled or not. */
+	disabled?: boolean;
+	/**
+	 * Restricts scopes allowed for the client.
+	 *
+	 * If not defined, any scope can be requested.
+	 */
+	allowedScopes?: string[];
+	//---- Recommended client data ----//
+	userId?: string;
+	/** Created time */
+	createdAt?: Date;
+	/** Last updated time */
+	updatedAt?: Date;
+	/** Expires time */
+	expiresAt?: Date;
+	//---- UI Metadata ----//
+	/** The name of the client. */
+	name?: string;
+	/** Linkable uri of the client. */
+	uri?: string;
+	/** The icon of the client. */
+	icon?: string;
+	/** List of contacts for the client. */
+	contacts?: string[];
+	/** Client Terms of Service Uri */
+	tos?: string;
+	/** Client Privacy Policy Uri */
+	policy?: string;
+	//---- User Software Identifiers ----//
+	softwareId?: string;
+	softwareVersion?: string;
+	softwareStatement?: string;
+	//---- Authentication Metadata ----//
+	/**
+	 * List of registered redirect URLs. Must include the whole URL, including the protocol, port,
+	 * and path.
+	 *
+	 * For example, `https://example.com/auth/callback`
+	 */
+	redirectUris?: string[];
+	tokenEndpointAuthMethod?:
+		| "none"
+		| "client_secret_basic"
+		| "client_secret_post";
+	grantTypes?: GrantType[];
+	responseTypes?: "code"[];
+	//---- RFC6749 Spec ----//
+	/**
+	 * Indicates whether the client is public or confidential.
+	 * If public, refreshing tokens doesn't require
+	 * a client_secret. Clients are considered confidential by default.
+	 *
+	 * Uses `token_endpoint_auth_method` field or `type` field to determine
+	 *
+	 * Described https://www.rfc-editor.org/rfc/rfc6749.html#section-2.1
+	 *
+	 * @default undefined
+	 */
+	public?: boolean;
+	/**
+	 * The client type
+	 *
+	 * Described https://www.rfc-editor.org/rfc/rfc6749.html#section-2.1
+	 *
+	 * - web - A web application (confidential client)
+	 * - native - A mobile application (public client)
+	 * - user-agent-based - A user-agent-based application (public client)
+	 */
+	type?: "web" | "native" | "user-agent-based";
+	//---- All other metadata ----//
+	/** Used to indicate if consent screen can be skipped */
+	skipConsent?: boolean;
+	/**
+	 * Additional metadata about the client.
+	 */
+	metadata?: string; // in JSON format
+}
+
+export interface OAuthOpaqueAccessToken {
+	/**
+	 * The opaque access token.
+	 */
+	token: string;
+	/**
+	 * The client ID of the client that requested the access token.
+	 */
+	clientId: string;
+	/**
+	 * The session ID the access token is associated with.
+	 *
+	 * Not available in client credentials grant
+	 * where no user session is involved.
+	 */
+	sessionId?: string;
+	/**
+	 * The user ID the access token is associated with.
+	 *
+	 * Not available in client credentials grant
+	 * wher no user is involved.
+	 */
+	userId?: string;
+	/**
+	 * The refresh token the access token is associated with.
+	 *
+	 * Not available without the "offline_access" scope
+	 */
+	refreshId?: string;
+	/** The expiration date of the access token. */
+	expiresAt: Date;
+	/** The creation date of the access token. */
+	createdAt: Date;
+	/**
+	 * Scope granted for the access token.
+	 *
+	 * Shall match the refreshId.scopes if refreshId is provided.
+	 */
+	scopes: string[];
+}
+
+/**
+ * Refresh Token Database Schema
+ */
+export interface OAuthRefreshToken {
+	token: string;
+	sessionId: string;
+	userId: string;
+	clientId?: string;
+	expiresAt: Date;
+	createdAt: Date;
+	/**
+	 * Scopes granted for this refresh token.
+	 *
+	 * Considered Immutable once granted.
+	 */
+	scopes?: string[];
+}
+
+/**
+ * Consent Database Schema
+ */
+export interface OAuthConsent {
+	clientId: string;
+	userId: string;
+	scopes: string[];
+	consentGiven: boolean;
+	createdAt: Date;
+	updatedAt: Date;
+}

--- a/packages/better-auth/src/plugins/oauth-provider/types.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/types.ts
@@ -8,6 +8,23 @@ export type StoreTokenType =
 	| "refresh_token"
 	| "authorization_code";
 
+/**
+ * Context passed to customJwtClaims and customIdTokenClaims callbacks.
+ * Provides additional information about the OAuth flow.
+ */
+export interface CustomJwtClaimsContext {
+	/**
+	 * The session ID associated with this OAuth authorization flow.
+	 * Available for authorization_code and refresh_token grants.
+	 * Undefined for client_credentials grant (M2M tokens have no user session).
+	 */
+	sessionId?: string;
+	/**
+	 * The client ID making the request
+	 */
+	clientId: string;
+}
+
 export interface OAuthOptions {
 	/**
 	 * Custom schema definitions
@@ -250,6 +267,7 @@ export interface OAuthOptions {
 	customIdTokenClaims?: (
 		user: User,
 		scopes: string[],
+		context?: CustomJwtClaimsContext,
 	) => Awaitable<Record<string, any>>;
 	/**
 	 * Custom claims attached to access tokens.
@@ -257,6 +275,7 @@ export interface OAuthOptions {
 	customJwtClaims?: (
 		user: User,
 		scopes: string[],
+		context?: CustomJwtClaimsContext,
 	) => Awaitable<Record<string, any>>;
 	/**
 	 * Overwrite specific /.well-known/openid-configuration

--- a/packages/better-auth/src/plugins/oauth-provider/userinfo.test.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/userinfo.test.ts
@@ -138,7 +138,7 @@ describe("oauth userinfo", async () => {
 
 	// Registers a confidential client application to work with
 	beforeAll(async () => {
-		const response = await auth.api.registerOAuthClient({
+		const response = await auth.api.createOAuthClient({
 			headers,
 			body: {
 				redirect_uris: [redirectUri],

--- a/packages/better-auth/src/plugins/oauth-provider/userinfo.test.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/userinfo.test.ts
@@ -1,0 +1,288 @@
+import { beforeAll, describe, it, expect } from "vitest";
+import { getTestInstance } from "../../test-utils/test-instance";
+import { jwt } from "../jwt";
+import { oauthProvider } from "./oauth";
+import { createAuthClient } from "../../client";
+import type { OAuthClient } from "../../oauth-2.1/types";
+import { oauthProviderClient } from "./client";
+import {
+	createAuthorizationCodeRequest,
+	createAuthorizationURL,
+} from "../../oauth2";
+import { generateRandomString } from "../../crypto";
+import type { MakeRequired } from "../../types/helper";
+
+describe("oauth userinfo", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const rpBaseUrl = "http://localhost:5000";
+	const validAudience = "https://myapi.example.com";
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			jwt({
+				jwt: {
+					audience: validAudience,
+					issuer: authServerBaseUrl,
+				},
+			}),
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+		],
+	});
+
+	const { headers, user } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: {
+			customFetchImpl,
+			headers,
+		},
+	});
+
+	let oauthClient: OAuthClient | null;
+
+	const providerId = "test";
+	const redirectUri = `${rpBaseUrl}/api/auth/oauth2/callback/${providerId}`;
+	const state = "123";
+
+	async function createAuthUrl(
+		overrides?: Partial<Parameters<typeof createAuthorizationURL>[0]>,
+	) {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+		const codeVerifier = generateRandomString(32);
+		const url = await createAuthorizationURL({
+			id: providerId,
+			options: {
+				clientId: oauthClient?.client_id,
+				clientSecret: oauthClient?.client_secret,
+				redirectURI: redirectUri,
+			},
+			redirectURI: "",
+			authorizationEndpoint: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
+			state,
+			scopes: ["openid", "profile", "email", "offline_access"],
+			codeVerifier,
+			...overrides,
+		});
+		return {
+			url,
+			codeVerifier,
+		};
+	}
+
+	async function validateAuthCode(
+		overrides: MakeRequired<
+			Partial<Parameters<typeof createAuthorizationCodeRequest>[0]>,
+			"code"
+		>,
+	) {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const { body, headers } = createAuthorizationCodeRequest({
+			...overrides,
+			redirectURI: redirectUri,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+		});
+
+		const tokens = await client.$fetch<{
+			access_token?: string;
+			id_token?: string;
+			refresh_token?: string;
+			expires_in?: number;
+			expires_at?: number;
+			token_type?: string;
+			scope?: string;
+			[key: string]: unknown;
+		}>("/oauth2/token", {
+			method: "POST",
+			body: body,
+			headers: headers,
+		});
+
+		return tokens;
+	}
+
+	async function getTokens(
+		overrides?: Partial<Parameters<typeof createAuthUrl>[0]>,
+		resource?: string,
+	) {
+		const { url: authUrl, codeVerifier } = await createAuthUrl(overrides);
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		const url = new URL(callbackRedirectUrl);
+		return await validateAuthCode({
+			code: url.searchParams.get("code")!,
+			codeVerifier,
+			resource,
+		});
+	}
+
+	// Registers a confidential client application to work with
+	beforeAll(async () => {
+		const response = await auth.api.registerOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [redirectUri],
+				skip_consent: true,
+			},
+		});
+		expect(response?.client_id).toBeDefined();
+		expect(response?.user_id).toBeDefined();
+		expect(response?.client_secret).toBeDefined();
+		expect(response?.redirect_uris).toEqual([redirectUri]);
+		oauthClient = response;
+	});
+
+	it("should fail unauthenticated request", async () => {
+		const tokens = await getTokens();
+		expect(tokens.data?.access_token).toBeDefined();
+		const userinfo = await client.oauth2.userinfo();
+		expect(userinfo.error?.status).toBe(401);
+	});
+
+	it("should fail without the openid scope", async () => {
+		const tokens = await getTokens({
+			scopes: [],
+		});
+		expect(tokens.data?.access_token).toBeDefined();
+		const userinfo = await client.$fetch<Record<string, string>>(
+			"/oauth2/userinfo",
+			{
+				headers: {
+					authorization: tokens.data?.access_token ?? "",
+				},
+			},
+		);
+		expect(userinfo.error?.status).toBe(400);
+	});
+
+	it("should pass provide all user information - opaque", async () => {
+		const tokens = await getTokens();
+		expect(tokens.data?.access_token).toBeDefined();
+		const userinfo = await client.$fetch<Record<string, string>>(
+			"/oauth2/userinfo",
+			{
+				headers: {
+					authorization: tokens.data?.access_token ?? "",
+				},
+			},
+		);
+		expect(userinfo.data).toMatchObject({
+			sub: user.id,
+			name: user.name,
+			given_name: expect.any(String),
+			family_name: expect.any(String),
+			email: user.email,
+			email_verified: user.emailVerified,
+		});
+	});
+
+	it("should pass provide all user information - jwt", async () => {
+		const tokens = await getTokens(undefined, validAudience);
+		expect(tokens.data?.access_token).toBeDefined();
+		const userinfo = await client.$fetch<Record<string, string>>(
+			"/oauth2/userinfo",
+			{
+				headers: {
+					authorization: tokens.data?.access_token ?? "",
+				},
+			},
+		);
+		expect(userinfo.data).toMatchObject({
+			sub: user.id,
+			name: user.name,
+			given_name: expect.any(String),
+			family_name: expect.any(String),
+			email: user.email,
+			email_verified: user.emailVerified,
+		});
+	});
+
+	it("should pass provide scoped user information - sub only", async () => {
+		const tokens = await getTokens({
+			scopes: ["openid"],
+		});
+		expect(tokens.data?.access_token).toBeDefined();
+		const userinfo = await client.$fetch<Record<string, string>>(
+			"/oauth2/userinfo",
+			{
+				headers: {
+					authorization: tokens.data?.access_token ?? "",
+				},
+			},
+		);
+		expect(userinfo.data).toMatchObject({
+			sub: user.id,
+		});
+		expect(userinfo.data?.name).toBeUndefined();
+		expect(userinfo.data?.given_name).toBeUndefined();
+		expect(userinfo.data?.family_name).toBeUndefined();
+		expect(userinfo.data?.email).toBeUndefined();
+		expect(userinfo.data?.email_verified).toBeUndefined();
+	});
+
+	it("should pass provide scoped user information - profile only", async () => {
+		const tokens = await getTokens({
+			scopes: ["openid", "profile"],
+		});
+		expect(tokens.data?.access_token).toBeDefined();
+		const userinfo = await client.$fetch<Record<string, string>>(
+			"/oauth2/userinfo",
+			{
+				headers: {
+					authorization: tokens.data?.access_token ?? "",
+				},
+			},
+		);
+		expect(userinfo.data).toMatchObject({
+			sub: user.id,
+			name: user.name,
+			given_name: expect.any(String),
+			family_name: expect.any(String),
+		});
+		expect(userinfo.data?.email).toBeUndefined();
+		expect(userinfo.data?.email_verified).toBeUndefined();
+	});
+
+	it("should pass provide scoped user information - email only", async () => {
+		const tokens = await getTokens({
+			scopes: ["openid", "email"],
+		});
+		expect(tokens.data?.access_token).toBeDefined();
+		const userinfo = await client.$fetch<Record<string, string>>(
+			"/oauth2/userinfo",
+			{
+				headers: {
+					authorization: tokens.data?.access_token ?? "",
+				},
+			},
+		);
+		expect(userinfo.data).toMatchObject({
+			sub: user.id,
+			email: user.email,
+			email_verified: user.emailVerified,
+		});
+		expect(userinfo.data?.name).toBeUndefined();
+		expect(userinfo.data?.given_name).toBeUndefined();
+		expect(userinfo.data?.family_name).toBeUndefined();
+	});
+});

--- a/packages/better-auth/src/plugins/oauth-provider/userinfo.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/userinfo.ts
@@ -1,0 +1,91 @@
+import { APIError } from "../../api";
+import type { GenericEndpointContext } from "@better-auth/core";
+import type { User } from "../../types";
+import { validateAccessToken } from "./introspect";
+import type { OAuthOptions } from "./types";
+
+/**
+ * Provides shared /userinfo and id_token claims functionality
+ *
+ * @see https://openid.net/specs/openid-connect-core-1_0.html#NormalClaims
+ */
+export function userNormalClaims(user: User, scopes: string[]) {
+	const name = user.name.split(" ").filter((v) => v !== "");
+	const profile = {
+		name: user.name ?? undefined,
+		picture: user.image ?? undefined,
+		given_name: name.length > 1 ? name.slice(0, -1).join(" ") : undefined,
+		family_name: name.length > 1 ? name.at(-1) : undefined,
+	};
+	const email = {
+		email: user.email ?? undefined,
+		email_verified: user.emailVerified ?? false,
+	};
+
+	return {
+		sub: user.id ?? undefined,
+		...(scopes.includes("profile") ? profile : {}),
+		...(scopes.includes("email") ? email : {}),
+	};
+}
+
+/**
+ * Handles the /oauth2/userinfo endpoint
+ */
+export async function userInfoEndpoint(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions,
+) {
+	if (!ctx.request) {
+		throw new APIError("UNAUTHORIZED", {
+			error_description: "request not found",
+			error: "invalid_request",
+		});
+	}
+
+	const authorization = ctx.request.headers.get("authorization");
+	const token =
+		typeof authorization === "string" && authorization?.startsWith("Bearer ")
+			? authorization?.replace("Bearer ", "")
+			: authorization;
+	if (!token?.length) {
+		throw new APIError("UNAUTHORIZED", {
+			error_description: "authorization header not found",
+			error: "invalid_request",
+		});
+	}
+	const validate = await validateAccessToken(ctx, opts, token);
+
+	const scopes = (validate.scope as string | undefined)?.split(" ");
+	if (!scopes?.includes("openid")) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "Missing required scope",
+			error: "invalid_scope",
+		});
+	}
+
+	if (!validate.sub) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "user not found",
+			error: "invalid_request",
+		});
+	}
+
+	const user = await ctx.context.internalAdapter.findUserById(validate.sub);
+	if (!user) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "user not found",
+			error: "invalid_request",
+		});
+	}
+
+	const baseUserClaims = userNormalClaims(user, scopes ?? []);
+	const additionalInfoUserClaims =
+		opts.getAdditionalUserInfoClaim && scopes?.length
+			? await opts.getAdditionalUserInfoClaim(user, scopes)
+			: {};
+	return ctx.json({
+		...baseUserClaims,
+		...additionalInfoUserClaims,
+	});
+}

--- a/packages/better-auth/src/plugins/oauth-provider/utils.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/utils.ts
@@ -9,12 +9,13 @@ import type { OAuthOptions, StoreTokenType } from "./types";
 import { symmetricDecrypt, symmetricEncrypt } from "../../crypto";
 import { databaseToSchema, type DatabaseClient } from "./register";
 import { timingSafeEqual } from "crypto";
+import type { Auth } from "../../auth";
 
 /**
  * Gets the oAuth Provider Plugin
  * @internal
  */
-export const getOAuthProviderPlugin = (ctx: AuthContext) => {
+export const getOAuthProviderPlugin = (ctx: AuthContext | Auth) => {
 	return ctx.options.plugins?.find(
 		(plugin) => plugin.id === "oauthProvider",
 	) as ReturnType<typeof oauthProvider>;
@@ -24,7 +25,7 @@ export const getOAuthProviderPlugin = (ctx: AuthContext) => {
  * Gets the JWT Plugin
  * @internal
  */
-export const getJwtPlugin = (ctx: AuthContext) => {
+export const getJwtPlugin = (ctx: AuthContext | Auth) => {
 	const plugin = ctx.options.plugins?.find((plugin) => plugin.id === "jwt");
 	if (!plugin) {
 		throw new BetterAuthError("jwt_config", "jwt plugin not found");

--- a/packages/better-auth/src/plugins/oauth-provider/utils.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/utils.ts
@@ -1,0 +1,352 @@
+import { APIError } from "../../api";
+import type { AuthContext, GenericEndpointContext } from "@better-auth/core";
+import { BetterAuthError } from "@better-auth/core/error";
+import type { jwt } from "../jwt";
+import type { oauthProvider } from "../oauth-provider";
+import { base64, base64Url } from "@better-auth/utils/base64";
+import { createHash } from "@better-auth/utils/hash";
+import type { OAuthOptions, StoreTokenType } from "./types";
+import { symmetricDecrypt, symmetricEncrypt } from "../../crypto";
+import { databaseToSchema, type DatabaseClient } from "./register";
+import { timingSafeEqual } from "crypto";
+
+/**
+ * Gets the oAuth Provider Plugin
+ * @internal
+ */
+export const getOAuthProviderPlugin = (ctx: AuthContext) => {
+	return ctx.options.plugins?.find(
+		(plugin) => plugin.id === "oauthProvider",
+	) as ReturnType<typeof oauthProvider>;
+};
+
+/**
+ * Gets the JWT Plugin
+ * @internal
+ */
+export const getJwtPlugin = (ctx: AuthContext) => {
+	const plugin = ctx.options.plugins?.find((plugin) => plugin.id === "jwt");
+	if (!plugin) {
+		throw new BetterAuthError("jwt_config", "jwt plugin not found");
+	}
+	return plugin as ReturnType<typeof jwt>;
+};
+
+/**
+ * Get a client by ID, checking trusted clients first, then database
+ */
+export async function getClient(
+	ctx: GenericEndpointContext,
+	options: OAuthOptions,
+	clientId: string,
+) {
+	const trustedClient = options.trustedClients?.find(
+		(client) => client.clientId === clientId,
+	);
+	if (trustedClient) {
+		return trustedClient;
+	}
+	const dbClient = await ctx.context.adapter
+		.findOne<DatabaseClient>({
+			model: options.schema?.oauthClient?.modelName ?? "oauthClient",
+			where: [{ field: "clientId", value: clientId }],
+		})
+		.then((res) => {
+			if (!res) return null;
+			return databaseToSchema(res);
+		});
+	return dbClient;
+}
+
+/**
+ * Default client secret hasher using SHA-256
+ *
+ * @internal
+ */
+const defaultHasher = async (value: string) => {
+	const hash = await createHash("SHA-256").digest(
+		new TextEncoder().encode(value),
+	);
+	const hashed = base64Url.encode(new Uint8Array(hash), {
+		padding: false,
+	});
+	return hashed;
+};
+
+/**
+ * Decrypts a storedClientSecret for signing
+ *
+ * @internal
+ */
+export async function decryptStoredClientSecret(
+	ctx: GenericEndpointContext,
+	storageMethod: OAuthOptions["storeClientSecret"],
+	storedClientSecret: string,
+) {
+	if (storageMethod === "encrypted") {
+		return await symmetricDecrypt({
+			key: ctx.context.secret,
+			data: storedClientSecret,
+		});
+	} else if (typeof storageMethod === "object" && "decrypt" in storageMethod) {
+		return await storageMethod.decrypt(storedClientSecret);
+	}
+
+	throw new BetterAuthError(
+		`Unsupported decryption storageMethod type '${storageMethod}'`,
+	);
+}
+
+/**
+ * Verify stored client secret against provided client secret
+ *
+ * @internal
+ */
+async function verifyStoredClientSecret(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions,
+	storedClientSecret: string,
+	clientSecret?: string,
+): Promise<boolean> {
+	const storageMethod =
+		opts.storeClientSecret ?? (opts.disableJwtPlugin ? "encrypted" : "hashed");
+
+	if (clientSecret && opts.clientSecretPrefix) {
+		if (clientSecret.startsWith(opts.clientSecretPrefix)) {
+			clientSecret = clientSecret.replace(opts.clientSecretPrefix, "");
+		} else {
+			throw new APIError("UNAUTHORIZED", {
+				error_description: "invalid client_secret",
+				error: "invalid_client",
+			});
+		}
+	}
+
+	function sideChannelEqual(valueA: string, valueB: string) {
+		// Use timing-safe comparison to avoid side-channel leaks
+		const a = Buffer.from(valueA, "utf8");
+		const b = Buffer.from(valueB, "utf8");
+		// Inputs must be the same length for timingSafeEqual
+		return a.length === b.length && timingSafeEqual(a, b);
+	}
+
+	if (storageMethod === "hashed") {
+		const hashedClientSecret = clientSecret
+			? await defaultHasher(clientSecret)
+			: undefined;
+		return (
+			!!hashedClientSecret &&
+			sideChannelEqual(hashedClientSecret, storedClientSecret)
+		);
+	} else if (typeof storageMethod === "object" && "hash" in storageMethod) {
+		const hashedClientSecret = clientSecret
+			? await storageMethod.hash(clientSecret)
+			: undefined;
+		return (
+			!!hashedClientSecret &&
+			sideChannelEqual(hashedClientSecret, storedClientSecret)
+		);
+	} else if (
+		storageMethod === "encrypted" ||
+		(typeof storageMethod === "object" && "decrypt" in storageMethod)
+	) {
+		const decryptedClientSecret = await decryptStoredClientSecret(
+			ctx,
+			storageMethod,
+			storedClientSecret,
+		);
+		return (
+			!!clientSecret && sideChannelEqual(decryptedClientSecret, clientSecret)
+		);
+	}
+
+	throw new BetterAuthError(
+		`Unsupported verify storageMethod type '${storageMethod}'`,
+	);
+}
+
+/**
+ * Store client secret according to the configured storage method
+ *
+ * @internal
+ */
+export async function storeClientSecret(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions,
+	clientSecret: string,
+) {
+	const storageMethod =
+		opts.storeClientSecret ?? (opts.disableJwtPlugin ? "encrypted" : "hashed");
+
+	if (storageMethod === "encrypted") {
+		return await symmetricEncrypt({
+			key: ctx.context.secret,
+			data: clientSecret,
+		});
+	} else if (storageMethod === "hashed") {
+		return await defaultHasher(clientSecret);
+	} else if (typeof storageMethod === "object" && "hash" in storageMethod) {
+		return await storageMethod.hash(clientSecret);
+	} else if (typeof storageMethod === "object" && "encrypt" in storageMethod) {
+		return await storageMethod.encrypt(clientSecret);
+	}
+
+	throw new BetterAuthError(
+		`Unsupported storeClientSecret type '${storageMethod}'`,
+	);
+}
+
+/**
+ * Stores a token value (ie opaque tokens, refresh tokens, transaction tokens, verification codes)
+ * on the database in a secure hashed format.
+ *
+ * @internal
+ */
+export async function storeToken(
+	storageMethod: OAuthOptions["storeTokens"] = "hashed",
+	token: string,
+	type: StoreTokenType,
+) {
+	if (storageMethod === "hashed") {
+		return await defaultHasher(token);
+	} else if (typeof storageMethod === "object" && "hash" in storageMethod) {
+		return await storageMethod.hash(token, type);
+	}
+
+	throw new BetterAuthError(
+		`storeToken: unsupported storageMethod type '${storageMethod}'`,
+	);
+}
+
+/**
+ * Gets a hashed token value to find on the database.
+ *
+ * @internal
+ */
+export async function getStoredToken(
+	storageMethod: OAuthOptions["storeTokens"] = "hashed",
+	token: string,
+	type: StoreTokenType,
+) {
+	if (storageMethod === "hashed") {
+		const hashedClientSecret = await defaultHasher(token);
+		return hashedClientSecret;
+	} else if (typeof storageMethod === "object" && "hash" in storageMethod) {
+		const hashedClientSecret = await storageMethod.hash(token, type);
+		return hashedClientSecret;
+	}
+
+	throw new BetterAuthError(
+		`getStoredToken: unsupported storageMethod type '${storageMethod}'`,
+	);
+}
+
+/**
+ * Converts a BASIC authorization header
+ * into its client_id and client_secret representation
+ *
+ * @internal
+ */
+export function basicToClientCredentials(authorization: string) {
+	if (authorization.startsWith("Basic ")) {
+		const encoded = authorization.replace("Basic ", "");
+		const decoded = new TextDecoder().decode(base64.decode(encoded));
+		if (!decoded.includes(":")) {
+			throw new APIError("BAD_REQUEST", {
+				error_description: "invalid authorization header format",
+				error: "invalid_client",
+			});
+		}
+		const [id, secret] = decoded.split(":", 2);
+		if (!id || !secret) {
+			throw new APIError("BAD_REQUEST", {
+				error_description: "invalid authorization header format",
+				error: "invalid_client",
+			});
+		}
+		return {
+			client_id: id,
+			client_secret: secret,
+		};
+	}
+}
+
+/**
+ * Validates client credentials failing on mismatches
+ * and incorrectly provided information
+ *
+ * @internal
+ */
+export async function validateClientCredentials(
+	ctx: GenericEndpointContext,
+	options: OAuthOptions,
+	clientId: string,
+	clientSecret?: string, // optional because required if client is confidential or this value is defined
+	scopes?: string[], // checks requested scopes against allowed scopes
+) {
+	const client = await getClient(ctx, options, clientId);
+	if (!client) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "missing client",
+			error: "invalid_client",
+		});
+	}
+	if (client.disabled) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "client is disabled",
+			error: "invalid_client",
+		});
+	}
+
+	// Require secret for confidential clients
+	if (!client.public && !clientSecret) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "client secret must be provided",
+			error: "invalid_client",
+		});
+	}
+
+	// Secret should not be received
+	if (clientSecret && !client.clientSecret) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "public client, client secret should not be received",
+			error: "invalid_client",
+		});
+	}
+
+	// Compare Secrets when secret is provided
+	if (
+		clientSecret &&
+		!(await verifyStoredClientSecret(
+			ctx,
+			options,
+			client.clientSecret!,
+			clientSecret,
+		))
+	) {
+		throw new APIError("UNAUTHORIZED", {
+			error_description: "invalid client_secret",
+			error: "invalid_client",
+		});
+	}
+
+	// If allowed scopes if set, must check against scopes
+	if (client.allowedScopes) {
+		if (!scopes) {
+			throw new APIError("BAD_REQUEST", {
+				error_description: "must request a scope",
+				error: "invalid_scope",
+			});
+		}
+		for (const sc of scopes) {
+			if (!client.allowedScopes.includes(sc)) {
+				throw new APIError("BAD_REQUEST", {
+					error_description: `client does not allow scope ${sc}`,
+					error: "invalid_scope",
+				});
+			}
+		}
+	}
+
+	return client;
+}

--- a/packages/better-auth/src/plugins/oauth-provider/verify.ts
+++ b/packages/better-auth/src/plugins/oauth-provider/verify.ts
@@ -1,0 +1,249 @@
+import {
+	createLocalJWKSet,
+	decodeProtectedHeader,
+	jwtVerify,
+	UnsecuredJWT,
+	type JSONWebKeySet,
+	type JWTPayload,
+	type JWTVerifyOptions,
+	type ProtectedHeaderParameters,
+} from "jose";
+import type { GenericEndpointContext } from "@better-auth/core";
+import { getJwtPlugin } from "./utils";
+import { APIError } from "better-call";
+import type { OAuthOptions } from "./types";
+
+/** Last fetched jwks */
+// Never export (used locally in ONLY verifyJwsAccessToken)
+let jwks: JSONWebKeySet | undefined;
+
+/**
+ * Performs local verification of an access token for your APIs.
+ *
+ * Can also be configured for remote verification.
+ *
+ * @internal
+ */
+export async function verifyJwsAccessToken(
+	token: string,
+	opts: {
+		/** Jwks url or promise of a Jwks */
+		jwksFetch: string | (() => Promise<JSONWebKeySet | undefined>);
+		/** Verify options */
+		verifyOptions: JWTVerifyOptions &
+			Required<Pick<JWTVerifyOptions, "audience" | "issuer">>;
+	},
+) {
+	// Attempt to decode the token and find a matching kid in jwks
+	let jwtHeaders: ProtectedHeaderParameters | undefined;
+	try {
+		jwtHeaders = decodeProtectedHeader(token);
+	} catch (error) {
+		if (error instanceof Error) throw error;
+		throw new Error(error as unknown as string);
+	}
+
+	if (!jwtHeaders.kid) throw new Error("Missing jwt kid");
+
+	// Fetch jwks if not set or has a different kid than the one stored
+	if (!jwks || !jwks.keys.find((jwk) => jwk.kid === jwtHeaders.kid)) {
+		jwks =
+			typeof opts.jwksFetch === "string"
+				? await fetch(opts.jwksFetch, {
+						headers: {
+							Accept: "application/json",
+						},
+					}).then(async (res) => {
+						if (!res.ok) throw new Error(`Jwks error: status ${res.status}`);
+						return (await res.json()) as JSONWebKeySet | undefined;
+					})
+				: await opts.jwksFetch();
+		if (!jwks) throw new Error("No jwks found");
+	}
+
+	// Actually verify token
+	try {
+		const jwt = await jwtVerify<JWTPayload>(
+			token,
+			createLocalJWKSet(jwks),
+			opts.verifyOptions,
+		);
+		return jwt.payload;
+	} catch (error) {
+		if (error instanceof Error) throw error;
+		throw new Error(error as unknown as string);
+	}
+}
+
+interface VerifyAccessTokenRemote {
+	/** Full url of the introspect endpoint. Should end with `/oauth2/introspect` */
+	introspectUrl: string;
+	/** Client Secret */
+	clientId: string;
+	/** Client Secret */
+	clientSecret: string;
+	/**
+	 * Forces remote verification of a token.
+	 * This ensures attached session (if applicable)
+	 * is also still active.
+	 */
+	force?: boolean;
+}
+
+/**
+ * Performs local verification of an access token for your API.
+ *
+ * Can also be configured for remote verification.
+ *
+ * @external
+ */
+export async function verifyAccessToken(
+	token: string,
+	opts: {
+		/** Verify options */
+		verifyOptions: JWTVerifyOptions &
+			Required<Pick<JWTVerifyOptions, "audience" | "issuer">>;
+		/** Scopes to additionally verify. Token must include all but not exact. */
+		scopes?: string[];
+		/** Required to verify access token locally */
+		jwksUrl?: string;
+		/** If provided, can verify a token remotely */
+		remoteVerify?: VerifyAccessTokenRemote;
+	},
+) {
+	let payload: JWTPayload | undefined;
+	// Locally verify
+	if (opts.jwksUrl && !opts?.remoteVerify?.force) {
+		try {
+			payload = await verifyJwsAccessToken(token, {
+				jwksFetch: opts.jwksUrl,
+				verifyOptions: opts.verifyOptions,
+			});
+		} catch (error) {
+			if (error instanceof Error) {
+				if (error.name === "TypeError" || error.name === "JWSInvalid") {
+					// likely an opaque token (continue)
+				} else {
+					throw error;
+				}
+			} else {
+				throw new Error(error as unknown as string);
+			}
+		}
+	}
+
+	// Remote verify
+	if (opts?.remoteVerify) {
+		const introspect = await fetch(opts.remoteVerify.introspectUrl, {
+			method: "POST",
+			headers: {
+				Accept: "application/json",
+				"Content-Type": "application/x-www-form-urlencoded",
+			},
+			body: new URLSearchParams({
+				client_id: opts.remoteVerify.clientId,
+				client_secret: opts.remoteVerify.clientSecret,
+				token,
+				token_type_hint: "access_token",
+			}).toString(),
+		}).then(async (res) => {
+			if (!res.ok) throw new Error(`Introspect error: status ${res.status}`);
+			return (await res.json()) as
+				| (JWTPayload & {
+						active: boolean;
+				  })
+				| undefined;
+		});
+		if (!introspect || !introspect?.active) throw new Error("inactive");
+		// Verifies payload using verify options (token valid through introspect)
+		try {
+			const unsecuredJwt = new UnsecuredJWT(introspect).encode();
+			const { audience, ...verifyOptions } = opts.verifyOptions;
+			const verify = introspect.aud
+				? UnsecuredJWT.decode(unsecuredJwt, opts.verifyOptions)
+				: UnsecuredJWT.decode(unsecuredJwt, verifyOptions);
+			payload = verify.payload;
+		} catch (error) {
+			throw new Error(error as unknown as string);
+		}
+	}
+
+	if (!payload) throw new Error("missing payload");
+
+	// Check scopes if provided
+	if (opts.scopes) {
+		const scopes = (payload.scope as string | undefined)?.split(" ");
+		for (const sc of opts.scopes) {
+			if (!scopes?.includes(sc)) {
+				throw new APIError("FORBIDDEN", {
+					message: `invalid scope ${sc}`,
+				});
+			}
+		}
+	}
+
+	return payload;
+}
+
+/**
+ * Performs verification of an access token for your API
+ * using the oAuth configuration values.
+ *
+ * Utilizes `verifyAccessToken` under the hood.
+ */
+export async function introspectVerifyEndpoint(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions,
+	token?: string,
+	verifyOpts?: {
+		/** Verify options */
+		verifyOptions?: JWTVerifyOptions;
+		/** Scopes to additionally verify. Token must include all but not exact. */
+		scopes?: string[];
+		/** If provided, can verify a token remotely */
+		remoteVerify?: Omit<VerifyAccessTokenRemote, "introspectUrl">;
+	},
+) {
+	const jwtPlugin = opts.disableJwtPlugin
+		? undefined
+		: getJwtPlugin(ctx.context);
+	const baseURL = ctx.context.baseURL;
+
+	if (!token) {
+		throw new APIError("UNAUTHORIZED", {
+			message: "missing access token",
+		});
+	}
+
+	try {
+		const accessToken = await verifyAccessToken(token, {
+			verifyOptions: {
+				audience: jwtPlugin?.options?.jwt?.audience ?? baseURL,
+				issuer: jwtPlugin?.options?.jwt?.issuer ?? baseURL,
+				...verifyOpts?.verifyOptions,
+			},
+			scopes: verifyOpts?.scopes,
+			jwksUrl: opts.disableJwtPlugin
+				? undefined
+				: (jwtPlugin?.options?.jwks?.remoteUrl ?? `${baseURL}/jwks`),
+			remoteVerify: verifyOpts?.remoteVerify
+				? {
+						...verifyOpts.remoteVerify,
+						introspectUrl: `${baseURL}/oauth2/introspect`,
+					}
+				: undefined,
+		});
+		return accessToken;
+	} catch (error) {
+		if (error instanceof APIError) {
+			throw error;
+		} else if (error instanceof Error) {
+			throw new APIError("UNAUTHORIZED", {
+				message: error.message,
+			});
+		}
+		throw new APIError("UNAUTHORIZED", {
+			message: error as unknown as string,
+		});
+	}
+}

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -127,6 +127,8 @@ export const getMetadata = (
  *
  * @param options - The options for the OIDC plugin.
  * @returns A Better Auth plugin.
+ *
+ * @deprecated Use [oauthProvider](../oauth-provider/index.ts) instead
  */
 export const oidcProvider = (options: OIDCOptions) => {
 	const modelName = {

--- a/packages/better-auth/src/types/helper.ts
+++ b/packages/better-auth/src/types/helper.ts
@@ -10,6 +10,8 @@ export type LiteralString = "" | (string & Record<never, never>);
 export type LiteralNumber = 0 | (number & Record<never, never>);
 
 export type Awaitable<T> = Promise<T> | T;
+export type MakeRequired<T, K extends keyof T> = Omit<T, K> &
+	Required<Pick<T, K>>;
 export type OmitId<T extends { id: unknown }> = Omit<T, "id">;
 
 export type Prettify<T> = Omit<T, never>;

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -164,6 +164,13 @@ export const supportedPlugins = [
 		clientPath: "better-auth/client/plugins",
 	},
 	{
+		id: "oauth-provider",
+		name: "oAuthProvider",
+		clientName: "oauthProviderClient",
+		path: `better-auth/plugins`,
+		clientPath: "better-auth/client/plugins",
+	},
+	{
 		id: "oauth-proxy",
 		name: "oAuthProxy",
 		clientName: undefined,


### PR DESCRIPTION
### Problem

  When using `customJwtClaims` or `customIdTokenClaims` in multi-tenant applications, there was no way to determine which specific session was being used for token
  generation. This caused issues when:

  - A user has multiple active sessions (e.g., different browser tabs)
  - Each session has different context (e.g., different active organization)
  - Token generation needs to query session-specific data

  **Example failure scenario:**
  ```typescript
  // User has two sessions:
  // Session A: activeOrganizationId = "org-1" (created at 10:00)
  // Session B: activeOrganizationId = "org-2" (created at 10:05)

  customJwtClaims: async (user, scopes) => {
    // ❌ No way to know which session triggered this
    // Guessing by latest createdAt gets wrong org on refresh
    const session = await db.query.session.findFirst({
      where: eq(s.userId, user.id),
      orderBy: desc(s.createdAt) // Always picks Session B
    });
    return { organizationId: session.activeOrganizationId };
  }
  ```
  
### Solution


Added an optional context parameter to `customJwtClaims` and `customIdTokenClaims` containing:
  - sessionId: The exact session ID from the OAuth flow (undefined for M2M client_credentials)
  - clientId: The OAuth client making the request

This leverages the existing OIDC sid claim that's already tracked internally, exposing it to custom claim functions for precise session lookups.

Having the sessionId in context lets you enrich the JWT with database lookups BEFORE it's signed

### Changes

  Type Definitions

  - Added CustomJwtClaimsContext interface
  - Updated customJwtClaims and customIdTokenClaims signatures with optional third parameter

  Token Generation

  - createJwtAccessToken: Passes context with sessionId and clientId
  - createIdToken: Accepts sessionId parameter and passes context
  - createUserTokens: Threads sessionId through to ID token creation

### Tests

  - Added 6 tests across 2 new test suites in `token.test.ts`
  - Verifies session context flows correctly through authorization_code → refresh_token
  - Confirms M2M tokens correctly have undefined sessionId
  - Tests backward compatibility with existing callback signature